### PR TITLE
Use discovery swarm

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "object.values": "^1.0.4",
     "osm-p2p-syncfile": "^1.3.0",
     "randombytes": "^2.0.6",
+    "statuses": "^1.5.0",
     "through2": "^3.0.0",
     "xtend": "^4.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -20,19 +20,14 @@
   "dependencies": {
     "asar": "^0.14.3",
     "blob-store-replication-stream": "^1.1.2",
-    "bonjour": "github:karissa/bonjour",
     "debug": "^3.1.0",
+    "discovery-swarm": "^5.1.4",
     "end-of-stream": "^1.4.1",
     "hyperlog-sneakernet-replicator": "^1.1.5",
-    "inherits": "^2.0.3",
     "object.values": "^1.0.4",
     "osm-p2p-syncfile": "^1.3.0",
-    "pump": "^3.0.0",
-    "pumpify": "^1.5.1",
     "randombytes": "^2.0.6",
-    "statuses": "^1.5.0",
     "through2": "^3.0.0",
-    "websocket-stream": "^5.1.2",
     "xtend": "^4.0.1"
   },
   "devDependencies": {

--- a/sync.js
+++ b/sync.js
@@ -1,12 +1,9 @@
 const path = require('path')
-const wsock = require('websocket-stream')
-const wsockstream = require('websocket-stream/stream')
-const http = require('http')
 const createMediaReplicationStream = require('blob-store-replication-stream')
 const sneakernet = require('hyperlog-sneakernet-replicator')
 const Syncfile = require('osm-p2p-syncfile')
 const debug = require('debug')('mapeo-sync')
-const Bonjour = require('bonjour')
+const Swarm = require('discovery-swarm')
 const values = require('object.values')
 const events = require('events')
 const fs = require('fs')
@@ -20,20 +17,65 @@ const SYNCFILE_FORMATS = {
   'osm-p2p-syncfile'   : 2
 }
 
+const DEFAULT_OPTS = {
+  dns: {
+    interval: 3000
+  },
+  dht: false
+}
+
+function WifiTarget (peer) {
+  peer.type = 'wifi'
+  return peer
+}
+
+function FileTarget (filename) {
+  return {
+    id: path.basename(filename),
+    filename,
+    type: 'file'
+  }
+}
+
 class Sync extends events.EventEmitter {
   constructor (osm, media, opts) {
     super()
-    if (!opts) opts = {}
+    this.opts = Object.assign(DEFAULT_OPTS, opts)
     opts.writeFormat = opts.writeFormat || 'hyperlog-sneakernet'
     if (!SYNCFILE_FORMATS[opts.writeFormat]) throw new Error('unknown syncfile write format: ' + opts.writeFormat)
 
     this.osm = osm
     this.media = media
-    this.host = opts.host
-    this.id = opts.id || 'Mapeo_' + randombytes(8).toString('hex')
+    this.id = opts.id || randombytes(8).toString('hex')
     this.opts = opts
+
+    // track replication progress states of files and wifi streams
     this._targets = {}
-    this._replicationServer = null
+
+    this.swarm = null
+  }
+
+  _swarm () {
+    this.swarm = Swarm()
+    this.swarm.on('connection-closed', (connection, info) => {
+      const target = WifiTarget(info)
+      this.emit('down', target)
+      debug('down', target)
+      delete this._targets[target.id]
+    })
+
+    this.swarm.on('connection', (connection, info) => {
+      // Skip your own machine.
+      if (info.id === this.id) {
+        debug('skipping sync target: it\'s me')
+        return
+      }
+
+      const target = WifiTarget(info)
+      this._targets[target.id] = target
+      this.emit('connection', target)
+      debug('connection', target)
+    })
     this._onerror = this._onerror.bind(this)
   }
 
@@ -41,160 +83,54 @@ class Sync extends events.EventEmitter {
     return values(this._targets)
   }
 
-  /**
-   * Sync to Target
-   * @type {[type]}
-   */
   syncToTarget (_target, opts) {
-    var self = this
-    if (!opts) opts = {}
-
-    const emitter = new events.EventEmitter()
-    const url = `ws://${_target.host}:${_target.port}`
-
-    var pending = 2
-    var target = this._targets[_target.name]
-
-    const done = (err) => {
-      if (err) {
-        if (target) {
-          target.status = 'replication-error'
-          target.message = err.message
-        }
-        return emitter.emit('error', err)
-      }
-      if (--pending === 0) {
-        if (target) {
-          target.status = 'replication-complete'
-        }
-        emitter.emit('end')
-      }
-    }
-    emitter.emit('progress', 'replication-started')
-    if (target) target.status = 'replication-started'
-
-    const ws = wsock(`${url}/osm`, {
-      perMessageDeflate: false, objectMode: true
-    })
-    // TODO: real progress events
-    ws.once('data', () => {
-      if (target) target.status = 'osm-connected'
-      emitter.emit('progress', 'osm-connected')
-    })
-
-    const osm = self.osmReplicationStream(opts.osm)
-    replicate(osm, ws, done)
-
-    const ws2 = wsock(`${url}/media`, {
-      perMessageDeflate: false, objectMode: true
-    })
-    // TODO: real progress events
-    ws2.once('data', () => {
-      if (target) target.status = 'media-connected'
-      emitter.emit('progress', 'media-connected')
-    })
-    const media = self.mediaReplicationStream(opts.media)
-    replicate(media, ws2, done)
-    return emitter
   }
 
-  /**
-   * Convenience function for announcing and re-announcing
-   */
-  announce (opts, cb) {
-    if (typeof opts === 'function') {
-      cb = opts
-      opts = {}
-    }
-    if (!this.browser) {
-      this.browser = this.listen(Object.assign({}, this.opts, opts), cb)
-    } else {
-      this.browser.update()
-      cb()
-    }
+  _syncError (err, target) {
+    target.status = 'replication-error'
+    target.message = err.message
+  }
+
+  _syncComplete (target) {
+    target.status = 'replication-complete'
+  }
+
+  // FIXME: think about this API more
+  _syncProgress (target, percent) {
+    target.status = 'replication-progress'
+    target.percent = percent
+  }
+
+  _onMediaProgress (target, percent) {
+    target.status = 'media-connected'
+  }
+
+  _onOsmProgress (target, percent) {
+    target.status = 'osm-connected'
   }
 
   /**
    * Convenience function for unanouncing and leaving the swarm
    */
   unannounce (cb) {
-    var self = this
-    self._targets = {}
-    if (!self.bonjour) return cb()
-    self.bonjour.unpublishAll(function () {
-      self.browser = null
-      if (self._replicationServer) {
-        self._replicationServer.close(cb)
-        self._replicationServer = null
-      } else cb()
-    })
+    if (!this.swarm) return cb()
+    this.swarm.leave(SYNC_TYPE)
   }
 
   _onerror (err) {
     this.emit('error', err)
   }
 
+  listen (opts, cb) {
+    this.swarm.listen(Object.assign({}, this.opts, opts), cb)
+  }
+
   /**
    * Broadcast and listen to targets on mdns
    */
-  listen (opts, cb) {
-    var self = this
-    if (!opts) opts = {}
-    if (!cb) cb = function () {}
-    self._targets = {}
-    const type = opts.type || SYNC_TYPE
-    if (!this.bonjour) this.bonjour = Bonjour()
-    this._replicationServer = http.createServer(function (req, res) {})
-    const wss = wsock.createServer({noServer: true})
-
-    this._replicationServer.on('upgrade', function (req, socket, head) {
-      wss.handleUpgrade(req, socket, head, function (client) {
-        var stream
-        if (req.url === '/osm') stream = self.osmReplicationStream(opts.osm)
-        if (req.url === '/media') stream = self.mediaReplicationStream(opts.media)
-        if (!stream) return client.send('Not found')
-        replicate(stream, wsockstream(client), function (err) {
-          if (err) self._onerror(err)
-        })
-      })
-    })
-    wss.on('error', this._onerror)
-    this._replicationServer.on('error', this._onerror)
-    this._replicationServer.listen(done)
-
-    function done () {
-      debug('replication server live on port', self._replicationServer.address().port)
-      self.service = self.bonjour.publish({
-        name: self.id,
-        host: self.host,
-        type: type,
-        port: self._replicationServer.address().port
-      })
-      self.service.on('error', self._onerror)
-      self.service.once('up', cb)
-    }
-
-    const browser = this.bonjour.find({ type }, this._onerror)
-    browser.on('down', function (service) {
-      const target = WifiTarget(service)
-      self.emit('down', target)
-      debug('down', target)
-      delete self._targets[target.name]
-    })
-
-    browser.on('up', function (service) {
-      // Skip your own machine.
-      if (service.name === self.id) {
-        debug('skipping sync target: it\'s me')
-        return
-      }
-
-      const target = WifiTarget(service)
-      self._targets[target.name] = target
-      self.emit('connection', target)
-      debug('connection', target)
-    })
-    return browser
+  announce (opts, cb) {
+    if (this.swarm) return cb()
+    this.listen(opts, () => this.swarm.join(SYNC_TYPE, cb))
   }
 
   /**
@@ -205,20 +141,16 @@ class Sync extends events.EventEmitter {
   replicateFromFile (sourceFile) {
     var self = this
     const emitter = new events.EventEmitter()
-    const target = {
-      id: this.id,
-      name: path.basename(sourceFile),
-      filename: sourceFile,
-      type: 'file'
-    }
-    self._targets[target.name] = target
+
+    const target = FileTarget(sourceFile)
+    self._targets[target.id] = target
 
     // FIXME: this wraps & re-wraps the function each time this func is called!
     const replicateOrig = this.osm.log.replicate
     this.osm.log.replicate = function () {
       const stream = replicateOrig.call(self.osm.log)
       stream.on('data', function () {
-        target.status = 'replication-progress'
+        self._syncProgress(target)
         emitter.emit('progress')
       })
       return stream
@@ -265,14 +197,13 @@ class Sync extends events.EventEmitter {
     }
 
     function onerror (err) {
-      target.status = 'replication-error'
-      target.message = err.message
+      self._syncError(err, target)
       emitter.emit('error', err)
     }
 
     function onend (err) {
       if (err) return onerror(err)
-      target.status = 'replication-complete'
+      self._syncComplete(target)
       self.osm.ready(function () {
         emitter.emit('end')
       })
@@ -290,13 +221,11 @@ class Sync extends events.EventEmitter {
   }
 
   close (cb) {
-    if (!cb) cb = function () {}
-    var self = this
-    self.unannounce(function () {
-      if (!self.bonjour) return cb()
-      self.bonjour.destroy()
-      self.bonjour = undefined
-      cb()
+    if (!cb) cb = () => {}
+    this.unannounce(() => {
+      this.swarm.destroy(() => {
+        this.swarm = null
+      })
     })
   }
 }
@@ -331,16 +260,6 @@ function isGzipFile (filepath, cb) {
       })
     })
   })
-}
-
-function WifiTarget (service) {
-  return {
-    id: service.name,
-    name: service.host,
-    host: service.referer.address,
-    port: service.port,
-    type: 'wifi'
-  }
 }
 
 module.exports = Sync

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -21,7 +21,7 @@ function createStore (dir, opts) {
   var osm = Osm()
   var media = blobstore(dir)
   return new Mapeo(osm, media, Object.assign({}, opts, {
-    host: randombytes(8).toString('hex') // simulate two different hosts
+    id: randombytes(8).toString('hex')
   }))
 }
 


### PR DESCRIPTION
@noffle a start! 
tests probably don't pass anymore 

* use `id` instead of `name`. We will now handle per-device naming on the handshake rather than over mdns
* use discovery swarm instead of bonjour
* get rid of websockets for replication and use a single tcp or utp stream instead! yay
* use discovery-swarm to re-announce so that the frontend doesn't have to care about that

