### PR TITLE
selective media sync by device type

### DIFF
--- a/lib/sync-stream.js
+++ b/lib/sync-stream.js
@@ -18,17 +18,26 @@ function sync (db, media, opts) {
     m.emit('error', err)
   })
 
-  var m1 = bsync(media)
-  var m1s = m.createSharedStream('media')
-  pump(m1, m1s, m1, function (err) {
-    if (err) m.emit('error', err)
-  })
+  var m1
+
+  var remoteDeviceType
+  function mediaSyncFilter (filename) {
+    if (filename.startsWith('original/') && remoteDeviceType === 'mobile') return false
+    else return true
+  }
 
   // handshake protocol
   var shake = function (req, accept) {
     if (req.protocolVersion === 1) {
-      if (opts.handshake) opts.handshake(req, accept)
-      else accept()
+      remoteDeviceType = req.deviceType
+      m1 = bsync(media, { filter: mediaSyncFilter })
+      var m1s = m.createSharedStream('media')
+      pump(m1, m1s, m1, function (err) {
+        if (err) m.emit('error', err)
+      })
+      m1.once('finish', end)
+
+      if (opts.handshake) opts.handshake(req, accept); else accept()
     } else {
       accept(new Error('unexpected remote protocol version: ' + req.protocolVersion))
     }
@@ -38,11 +47,8 @@ function sync (db, media, opts) {
   // wrap in handshake
   var hand = handshake(m, payload, shake)
 
-  // TODO: what happens if an inner stream emits an error? does multiplex catch + propagate it?
-
   var pending = 2
   r.once('end', end)
-  m1.once('finish', end)
   function end () {
     if (--pending) return
     hand.goodFinish = true

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "osm-p2p": "^2.0.0",
     "osm-p2p-mem": "^1.0.0",
     "rimraf": "^2.6.2",
-    "safe-fs-blob-store": "1.0.0",
+    "safe-fs-blob-store": "^1.0.0",
     "standard": "^11.0.1",
     "tape": "^4.9.1"
   }

--- a/sync.js
+++ b/sync.js
@@ -34,7 +34,7 @@ class Sync extends events.EventEmitter {
     this.osm = osm
     this.media = media
     if (!opts.id) opts.id = randombytes(32)
-    this.opts = opts
+    this.opts = Object.assign({}, opts)
 
     // track discovered wifi peers
     this._targets = {}

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -8,11 +8,11 @@ var blobstore = require('safe-fs-blob-store')
 
 var Mapeo = require('..')
 
-var tmpdir = path.join(tmp(), 'mapfilter-sync-server-test-files')
+var tmpdir1 = path.join(tmp(), 'mapfilter-sync-server-test-files')
 var tmpdir2 = path.join(tmp(), 'mapfilter-sync-server-test-files-2')
 
 module.exports = {
-  tmpdir, tmpdir2, createApi, cleanupSync
+  tmpdir1, tmpdir2, createApi, cleanupSync
 }
 
 function createApi (dir, opts) {
@@ -26,6 +26,6 @@ function createApi (dir, opts) {
 }
 
 function cleanupSync () {
-  rimraf.sync(tmpdir)
+  rimraf.sync(tmpdir1)
   rimraf.sync(tmpdir2)
 }

--- a/test/observations.js
+++ b/test/observations.js
@@ -22,7 +22,7 @@ var obs2 = {
 }
 
 test('observationCreate', function (t) {
-  var m = helpers.createApi(helpers.tmpdir)
+  var m = helpers.createApi(helpers.tmpdir1)
   m.observationCreate(obs, (err, node) => {
     t.error(err)
     t.ok(node.id)
@@ -40,7 +40,7 @@ test('observationCreate', function (t) {
 })
 
 test('observationUpdate', function (t) {
-  var m = helpers.createApi(helpers.tmpdir)
+  var m = helpers.createApi(helpers.tmpdir1)
   m.observationCreate(obs, (err, node) => {
     t.error(err)
     var newObs = Object.assign(obs2, {})
@@ -59,7 +59,7 @@ test('observationUpdate', function (t) {
 })
 
 test('observationList', function (t) {
-  var m = helpers.createApi(helpers.tmpdir)
+  var m = helpers.createApi(helpers.tmpdir1)
   m.observationCreate(obs, (err, node1) => {
     t.error(err)
     m.observationList((err, list) => {
@@ -84,7 +84,7 @@ test('observationList', function (t) {
 })
 
 test('observationList with limit=1', function (t) {
-  var m = helpers.createApi(helpers.tmpdir)
+  var m = helpers.createApi(helpers.tmpdir1)
   m.observationCreate(obs, (err, node1) => {
     t.error(err)
     m.observationList((err, list) => {
@@ -105,7 +105,7 @@ test('observationList with limit=1', function (t) {
 })
 
 test('observationDelete', function (t) {
-  var m = helpers.createApi(helpers.tmpdir)
+  var m = helpers.createApi(helpers.tmpdir1)
   m.observationCreate(obs, (err, node) => {
     t.error(err)
     m.observationDelete(node.id, (err) => {
@@ -126,7 +126,7 @@ test('observationDelete', function (t) {
 
 test('observationStream', function (t) {
   t.plan(4)
-  var m = helpers.createApi(helpers.tmpdir)
+  var m = helpers.createApi(helpers.tmpdir1)
   m.observationCreate(obs, (err, node1) => {
     t.error(err)
     var newObs = Object.assign(obs2, {})
@@ -147,7 +147,7 @@ test('observationStream', function (t) {
 
 test('observationStream with options', function (t) {
   t.plan(4)
-  var m = helpers.createApi(helpers.tmpdir)
+  var m = helpers.createApi(helpers.tmpdir1)
   m.observationCreate(obs, (err, node1) => {
     t.error(err)
     var newObs = Object.assign(obs2, {})

--- a/test/sync.js
+++ b/test/sync.js
@@ -10,7 +10,7 @@ function createApis (opts, cb) {
     opts = undefined
   }
   opts = opts || {}
-  var api1 = helpers.createApi(helpers.tmpdir, opts.api1)
+  var api1 = helpers.createApi(helpers.tmpdir1, opts.api1)
   var api2 = helpers.createApi(helpers.tmpdir2, opts.api2)
   api1.on('error', console.error)
   api2.on('error', console.error)
@@ -102,10 +102,12 @@ tape('sync: replication of a simple observation with media', function (t) {
           api2.osm.get(id, function (err, _node) {
             t.error(err)
             t.same(node, _node, 'node replicated successfully')
-            t.ok(fs.existsSync(path.join(helpers.tmpdir2, 'foo', 'foo.txt')), 'media replicated')
-            t.equal(fs.readFileSync(path.join(helpers.tmpdir2, 'foo', 'foo.txt')).toString(), 'bar', 'media replicated')
-            close(function () {
-              t.ok(true)
+            api2.media.exists('foo.txt', function (err, exists) {
+              t.error(err)
+              t.ok(exists)
+              close(function () {
+                t.ok(true)
+              })
             })
           })
         })

--- a/test/sync.js
+++ b/test/sync.js
@@ -272,12 +272,12 @@ tape('sync: media: desktop <-> desktop', function (t) {
         ]
         api1.media.list(function (err, files) {
           t.error(err)
-          t.deepEquals(files, expected)
+          t.deepEquals(files.sort(), expected.sort())
           if (!--pending) close(() => t.ok(true))
         })
         api2.media.list(function (err, files) {
           t.error(err)
-          t.deepEquals(files, expected)
+          t.deepEquals(files.sort(), expected.sort())
           if (!--pending) close(() => t.ok(true))
         })
       })
@@ -355,12 +355,12 @@ tape('sync: media: mobile <-> desktop', function (t) {
         ]
         api1.media.list(function (err, files) {
           t.error(err)
-          t.deepEquals(files, expected1)
+          t.deepEquals(files.sort(), expected1.sort())
           if (!--pending) close(() => t.ok(true))
         })
         api2.media.list(function (err, files) {
           t.error(err)
-          t.deepEquals(files, expected2)
+          t.deepEquals(files.sort(), expected2.sort())
           if (!--pending) close(() => t.ok(true))
         })
       })
@@ -437,12 +437,12 @@ tape('sync: media: mobile <-> mobile', function (t) {
         ]
         api1.media.list(function (err, files) {
           t.error(err)
-          t.deepEquals(files, expected1)
+          t.deepEquals(files.sort(), expected1.sort())
           if (!--pending) close(() => t.ok(true))
         })
         api2.media.list(function (err, files) {
           t.error(err)
-          t.deepEquals(files, expected2)
+          t.deepEquals(files.sort(), expected2.sort())
           if (!--pending) close(() => t.ok(true))
         })
       })

--- a/test/sync.js
+++ b/test/sync.js
@@ -10,8 +10,8 @@ function createApis (opts, cb) {
     opts = undefined
   }
   opts = opts || {}
-  var api1 = helpers.createApi(helpers.tmpdir, opts)
-  var api2 = helpers.createApi(helpers.tmpdir2, opts)
+  var api1 = helpers.createApi(helpers.tmpdir, opts.api1)
+  var api2 = helpers.createApi(helpers.tmpdir2, opts.api2)
   api1.on('error', console.error)
   api2.on('error', console.error)
   function close (cb) {
@@ -26,14 +26,6 @@ function createApis (opts, cb) {
     helpers.cleanupSync()
   }
   cb(api1, api2, close)
-}
-
-function verifyTarget (t, api, done) {
-  return (target) => {
-    var address = api.sync.swarm.address()
-    t.same(target.port, address.port, 'target port')
-    done()
-  }
 }
 
 tape('sync: two servers find eachother', function (t) {
@@ -123,7 +115,7 @@ tape('sync: replication of a simple observation with media', function (t) {
 })
 
 tape('sync: syncfile replication: hyperlog-sneakernet', function (t) {
-  createApis({writeFormat: 'hyperlog-sneakernet'}, function (api1, api2, close) {
+  createApis({api1:{writeFormat: 'hyperlog-sneakernet'}}, function (api1, api2, close) {
     // create test data
     var id
     var tmpfile = path.join(os.tmpdir(), 'sync1-' + Math.random().toString().substring(2))
@@ -168,7 +160,7 @@ tape('sync: syncfile replication: hyperlog-sneakernet', function (t) {
 })
 
 tape('sync: syncfile replication: osm-p2p-syncfile', function (t) {
-  createApis({writeFormat: 'osm-p2p-syncfile'}, function (api1, api2, close) {
+  createApis({api1:{writeFormat: 'osm-p2p-syncfile'}}, function (api1, api2, close) {
     // create test data
     var id
     var tmpfile = path.join(os.tmpdir(), 'sync1-' + Math.random().toString().substring(2))

--- a/test/sync.js
+++ b/test/sync.js
@@ -208,3 +208,244 @@ tape('sync: syncfile replication: osm-p2p-syncfile', function (t) {
     }
   })
 })
+
+tape('sync: media: desktop <-> desktop', function (t) {
+  t.plan(18)
+
+  function writeBlob (api, filename, cb) {
+    var pending = 3
+    var ws = api.media.createWriteStream('original/' + filename, done)
+    ws.end(filename)
+
+    ws = api.media.createWriteStream('preview/' + filename, done)
+    ws.end(filename)
+
+    ws = api.media.createWriteStream('thumbnail/' + filename, done)
+    ws.end(filename)
+
+    function done (err) {
+      t.error(err)
+      if (!--pending) cb()
+    }
+  }
+
+  var opts = {api1:{deviceType:'desktop'}, api2:{deviceType:'desktop'}}
+  createApis(opts, function (api1, api2, close) {
+    var pending = 4
+
+    api1.sync.listen()
+    api1.sync.on('target', written.bind(null, null))
+    api2.sync.listen()
+    api2.sync.on('target', written.bind(null, null))
+    writeBlob(api1, 'hello_world.png', written)
+    writeBlob(api2, 'goodbye_world.png', written)
+
+    function written (err) {
+      t.error(err)
+      if (--pending === 0) {
+        t.ok(api1.sync.targets().length > 0, 'api 1 has targets')
+        t.ok(api2.sync.targets().length > 0, 'api 2 has targets')
+        if (api1.sync.targets().length >= 1) {
+          sync(api1.sync.targets()[0])
+        }
+      }
+    }
+
+    function sync (target) {
+      var syncer = api1.sync.start(target)
+      syncer.on('error', function (err) {
+        t.error(err)
+        close()
+        t.fail()
+      })
+
+      syncer.on('end', function () {
+        t.ok(true, 'replication complete')
+        var pending = 2
+        var expected = [
+          'original/goodbye_world.png',
+          'original/hello_world.png',
+          'preview/goodbye_world.png',
+          'preview/hello_world.png',
+          'thumbnail/goodbye_world.png',
+          'thumbnail/hello_world.png'
+        ]
+        api1.media.list(function (err, files) {
+          t.error(err)
+          t.deepEquals(files, expected)
+          if (!--pending) close(() => t.ok(true))
+        })
+        api2.media.list(function (err, files) {
+          t.error(err)
+          t.deepEquals(files, expected)
+          if (!--pending) close(() => t.ok(true))
+        })
+      })
+    }
+  })
+})
+
+tape('sync: media: mobile <-> desktop', function (t) {
+  t.plan(18)
+
+  function writeBlob (api, filename, cb) {
+    var pending = 3
+    var ws = api.media.createWriteStream('original/' + filename, done)
+    ws.end(filename)
+
+    ws = api.media.createWriteStream('preview/' + filename, done)
+    ws.end(filename)
+
+    ws = api.media.createWriteStream('thumbnail/' + filename, done)
+    ws.end(filename)
+
+    function done (err) {
+      t.error(err)
+      if (!--pending) cb()
+    }
+  }
+
+  var opts = {api1:{deviceType:'mobile'}, api2:{deviceType:'desktop'}}
+  createApis(opts, function (api1, api2, close) {
+    var pending = 4
+
+    api1.sync.listen()
+    api1.sync.on('target', written.bind(null, null))
+    api2.sync.listen()
+    api2.sync.on('target', written.bind(null, null))
+    writeBlob(api1, 'hello_world.png', written)
+    writeBlob(api2, 'goodbye_world.png', written)
+
+    function written (err) {
+      t.error(err)
+      if (--pending === 0) {
+        t.ok(api1.sync.targets().length > 0, 'api 1 has targets')
+        t.ok(api2.sync.targets().length > 0, 'api 2 has targets')
+        if (api1.sync.targets().length >= 1) {
+          sync(api1.sync.targets()[0])
+        }
+      }
+    }
+
+    function sync (target) {
+      var syncer = api1.sync.start(target)
+      syncer.on('error', function (err) {
+        t.error(err)
+        close()
+        t.fail()
+      })
+
+      syncer.on('end', function () {
+        t.ok(true, 'replication complete')
+        var pending = 2
+        var expected1 = [
+          'original/hello_world.png',
+          'preview/goodbye_world.png',
+          'preview/hello_world.png',
+          'thumbnail/goodbye_world.png',
+          'thumbnail/hello_world.png'
+        ]
+        var expected2 = [
+          'original/goodbye_world.png',
+          'original/hello_world.png',
+          'preview/goodbye_world.png',
+          'preview/hello_world.png',
+          'thumbnail/goodbye_world.png',
+          'thumbnail/hello_world.png'
+        ]
+        api1.media.list(function (err, files) {
+          t.error(err)
+          t.deepEquals(files, expected1)
+          if (!--pending) close(() => t.ok(true))
+        })
+        api2.media.list(function (err, files) {
+          t.error(err)
+          t.deepEquals(files, expected2)
+          if (!--pending) close(() => t.ok(true))
+        })
+      })
+    }
+  })
+})
+
+tape('sync: media: mobile <-> mobile', function (t) {
+  t.plan(18)
+
+  function writeBlob (api, filename, cb) {
+    var pending = 3
+    var ws = api.media.createWriteStream('original/' + filename, done)
+    ws.end(filename)
+
+    ws = api.media.createWriteStream('preview/' + filename, done)
+    ws.end(filename)
+
+    ws = api.media.createWriteStream('thumbnail/' + filename, done)
+    ws.end(filename)
+
+    function done (err) {
+      t.error(err)
+      if (!--pending) cb()
+    }
+  }
+
+  var opts = {api1:{deviceType:'mobile'}, api2:{deviceType:'mobile'}}
+  createApis(opts, function (api1, api2, close) {
+    var pending = 4
+
+    api1.sync.listen()
+    api1.sync.on('target', written.bind(null, null))
+    api2.sync.listen()
+    api2.sync.on('target', written.bind(null, null))
+    writeBlob(api1, 'hello_world.png', written)
+    writeBlob(api2, 'goodbye_world.png', written)
+
+    function written (err) {
+      t.error(err)
+      if (--pending === 0) {
+        t.ok(api1.sync.targets().length > 0, 'api 1 has targets')
+        t.ok(api2.sync.targets().length > 0, 'api 2 has targets')
+        if (api1.sync.targets().length >= 1) {
+          sync(api1.sync.targets()[0])
+        }
+      }
+    }
+
+    function sync (target) {
+      var syncer = api1.sync.start(target)
+      syncer.on('error', function (err) {
+        t.error(err)
+        close()
+        t.fail()
+      })
+
+      syncer.on('end', function () {
+        t.ok(true, 'replication complete')
+        var pending = 2
+        var expected1 = [
+          'original/hello_world.png',
+          'preview/goodbye_world.png',
+          'preview/hello_world.png',
+          'thumbnail/goodbye_world.png',
+          'thumbnail/hello_world.png'
+        ]
+        var expected2 = [
+          'original/goodbye_world.png',
+          'preview/goodbye_world.png',
+          'preview/hello_world.png',
+          'thumbnail/goodbye_world.png',
+          'thumbnail/hello_world.png'
+        ]
+        api1.media.list(function (err, files) {
+          t.error(err)
+          t.deepEquals(files, expected1)
+          if (!--pending) close(() => t.ok(true))
+        })
+        api2.media.list(function (err, files) {
+          t.error(err)
+          t.deepEquals(files, expected2)
+          if (!--pending) close(() => t.ok(true))
+        })
+      })
+    }
+  })
+})


### PR DESCRIPTION
- depends on a new feature in blob-store-replication-stream (opts.filter) that lets you specify which files in your store to share
- waits to add the inner media sync stream until AFTER the remote handshake comes in, so ^^^ happens after we know the remote device type
- 3 new tests: desktop<->desktop, mobile<->desktop, mobile<->mobile