### PR TITLE
use osm-p2p-syncfile as the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ var Mapeo = require('@mapeo/core')
 
 ### `mapeo = new Mapeo(osm, media, opts)`
 
-* `osm`: an `osm-p2p-db` instance
-* `media`: a blob storage instance
+* `osm`: an `osm-p2p` (or `kappa-osm`) instance
+* `media`: a blob storage instance (e.g., `safe-fs-blob-store`)
 * `opts`: options
 
 Valid `opts` options include:

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ var Mapeo = require('@mapeo/core')
 
 ### `mapeo = new Mapeo(osm, media, opts)`
 
-* `osm`: an `osm-p2p` (or `kappa-osm`) instance
-* `media`: a blob storage instance (e.g., `safe-fs-blob-store`)
+* `osm`: an [osm-p2p](http://github.com/digidem/kappa-osm) (or [kappa-osm](http://github.com/digidem/kappa-osm)) instance
+* `media`: a blob storage instance (e.g., [safe-fs-blob-store](http://npmjs.com/safe-fs-blob-store))
 * `opts`: options
 
 Valid `opts` options include:

--- a/sync.js
+++ b/sync.js
@@ -27,7 +27,7 @@ class Sync extends events.EventEmitter {
   constructor (osm, media, opts) {
     super()
     opts = Object.assign(DEFAULT_OPTS, opts)
-    opts.writeFormat = opts.writeFormat || 'hyperlog-sneakernet'
+    opts.writeFormat = opts.writeFormat || 'osm-p2p-syncfile'
     if (!SYNCFILE_FORMATS[opts.writeFormat]) throw new Error('unknown syncfile write format: ' + opts.writeFormat)
 
     this.osm = osm

--- a/sync.js
+++ b/sync.js
@@ -138,7 +138,7 @@ class Sync extends events.EventEmitter {
 
           if (err) error = err
           if (!--pending) {
-            syncfile.userdata({'p2p-db': 'hyperlog'}, function () {
+            syncfile.userdata({'p2p-db': 'kappa-osm'}, function () {
               syncfile.close(onend.bind(null, error))
             })
           }


### PR DESCRIPTION
Mapeo Core doesn't support creating new[ syncfiles other than osm-p2p-syncfile](https://github.com/digidem/mapeo-core/blob/master/sync.js#L112-L113) so let's make that the default.

Does this line also need to be changed (it references `hyperlog`)? https://github.com/digidem/mapeo-core/blob/master/sync.js#L141