### PR TITLE
Be able to pass id when creating an observation

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,11 +30,13 @@ class Mapeo extends events.EventEmitter {
     newObs.schemaVersion = obs.schemaVersion || CURRENT_SCHEMA
     newObs.timestamp = (new Date().toISOString())
     newObs.created_at = (new Date()).toISOString()
+    if (obs.id) this.osm.put(obs.id, newObs, done)
+    else this.osm.create(newObs, done)
 
-    this.osm.create(newObs, function (err, node) {
+    function done (err, node) {
       if (err) return cb(err)
       cb(null, node)
-    })
+    }
   }
 
   observationGet (id, cb) {


### PR DESCRIPTION
This was useful when doing migration. If we don't want to include this in mainline, I could copy the code from the 'create observation' function instead, but I figured this could be useful in other cases. Thoughts?