### PR TITLE
pause indexing when there are > 0 syncs ongoing

### DIFF
--- a/lib/sync-stream.js
+++ b/lib/sync-stream.js
@@ -64,6 +64,7 @@ function sync (db, media, opts) {
         })
         m1.once('finish', end)
       }
+      hand.emit('sync-start')
       accept(err)
     }
   }

--- a/test/observations.js
+++ b/test/observations.js
@@ -148,7 +148,6 @@ test('observationDelete', function (t) {
           t.error(err)
           var deleted = list.filter((o) => o.id === node.id)
           t.same(deleted.length, 0, 'deleted not returned in list')
-          console.log(deleted)
           t.end()
         })
       })


### PR DESCRIPTION
This uses an internal variable to track the number of sync connections that have been accepted by both sides and are in progress. Once a sync stream terminates (stream ended/errored/destroyed) the reference count is decreased. Once it reaches zero, it asks kappa-core to resume indexing.