### PR TITLE
test: make sure errors are emitted and appear in sync state

### DIFF
--- a/lib/sync-stream.js
+++ b/lib/sync-stream.js
@@ -7,39 +7,17 @@ var pump = require('pump')
 var progressSync = require('./db-sync-progress')
 
 function sync (db, media, opts) {
-  var m = multiplex()
-  var progress = {
-    db: { sofar: 0, total: 0 },
-    media: { sofar: 0, total: 0 }
+  var payload = {
+    protocolVersion: 1,
+    deviceType: opts.deviceType,
+    deviceName: opts.deviceName
   }
-
-  var r = progressSync({osm:db}, {live: false, timeout: 0})
-  r.on('progress', function (sofar, total) {
-    progress.db.sofar = sofar
-    progress.db.total = total
-    hand.emit('progress', progress)
-  })
-
-  var p2p = m.createSharedStream('p2p')
-  // XXX: Using pipe() here instead of pump because of a bug in multifeed
-  // (probably) where both sides of the stream aren't being closed properly
-  // on end-of-stream.
-  r.pipe(p2p).pipe(r)
-  r.once('error', function (err) {
-    m.emit('error', err)
-  })
-
-  var m1
-
-  var remoteDeviceType
-  function mediaSyncFilter (filename) {
-    if (filename.startsWith('original/') && remoteDeviceType === 'mobile') return false
-    else return true
-  }
-
   // handshake protocol
   var accepted = false
-  var shake = function (req, accept) {
+
+  var m = multiplex()
+  // wrap in handshake
+  var hand = handshake(m, payload, function (req, accept) {
     if (req.protocolVersion === 1) {
       remoteDeviceType = req.deviceType
 
@@ -60,22 +38,43 @@ function sync (db, media, opts) {
         })
         var m1s = m.createSharedStream('media')
         pump(m1, m1s, m1, function (err) {
-          if (err) m.emit('error', err)
+          if (err) hand.emit('error', err)
         })
         m1.once('finish', end)
       }
       hand.emit('sync-start')
       accept(err)
     }
-  }
-  var payload = {
-    protocolVersion: 1,
-    deviceType: opts.deviceType,
-    deviceName: opts.deviceName
+  })
+
+  var m1
+  var progress = {
+    db: { sofar: 0, total: 0 },
+    media: { sofar: 0, total: 0 }
   }
 
-  // wrap in handshake
-  var hand = handshake(m, payload, shake)
+  var r = progressSync({osm:db}, {live: false, timeout: 0})
+  r.on('progress', function (sofar, total) {
+    progress.db.sofar = sofar
+    progress.db.total = total
+    hand.emit('progress', progress)
+  })
+
+  var p2p = m.createSharedStream('p2p')
+  // XXX: Using pipe() here instead of pump because of a bug in multifeed
+  // (probably) where both sides of the stream aren't being closed properly
+  // on end-of-stream.
+  r.pipe(p2p).pipe(r)
+  r.once('error', function (err) {
+    console.log('error')
+    hand.emit('error', err)
+  })
+
+  var remoteDeviceType
+  function mediaSyncFilter (filename) {
+    if (filename.startsWith('original/') && remoteDeviceType === 'mobile') return false
+    else return true
+  }
 
   var pending = 2
   r.once('end', end)

--- a/sync.js
+++ b/sync.js
@@ -17,22 +17,93 @@ const SYNCFILE_FORMATS = {
   'osm-p2p-syncfile'   : 2
 }
 
-const WIFI_READY = 'replication-wifi-ready'
-const REPLICATION_PROGRESS = 'replication-progress'
-const REPLICATION_COMPLETE = 'replication-complete'
-const REPLICATION_ERROR = 'replication-error'
-const REPLICATION_STARTED = 'replication-started'
-
-function PeerState (topic, message) {
-  return { topic, message }
-}
-
 const DEFAULT_OPTS = {
   dns: {
     interval: 3000
   },
   dht: false,
   utp: false
+}
+
+const states = {
+  WIFI_READY: 'replication-wifi-ready',
+  PROGRESS: 'replication-progress',
+  COMPLETE: 'replication-complete',
+  ERROR: 'replication-error',
+  STARTED: 'replication-started'
+}
+
+function PeerState (topic, message) {
+  return { topic, message }
+}
+
+class SyncState {
+  constructor () {
+    this._completed = {}
+    this._state = {}
+  }
+  add (peer) {
+    peer.sync = new events.EventEmitter()
+    var onprogress = (progress) => this.onprogress(peer, progress)
+    var onerror = (error) => this.onerror(peer, error)
+    var onend = () => {
+      peer.sync.removeListener('end', onend)
+      peer.sync.removeListener('error', onerror)
+      peer.sync.removeListener('progress', onprogress)
+    }
+
+    peer.sync.on('progress', onprogress)
+    peer.sync.on('error', onerror)
+    peer.sync.on('end', onend)
+
+    this._state[peer.name] = peer
+  }
+
+  get (host, port) {
+    var res = Object.values(this._state)
+      .filter(function (peer) {
+        return peer.port === port && peer.host === host
+      })
+    if (res.length) {
+      return res[0]
+    } else {
+      return null
+    }
+  }
+
+  clear () {
+    this._state = {}
+  }
+
+  onwifi (peer) {
+    peer.state = PeerState(states.WIFI_READY)
+  }
+
+  onstart (peer) {
+    peer.state = PeerState(states.STARTED)
+  }
+
+  onprogress (peer, progress) {
+    peer.state = PeerState(states.PROGRESS, progress)
+  }
+
+  onerror (peer, error) {
+    peer.state = PeerState(states.ERROR, error.message)
+  }
+
+  onend (peer) {
+    peer.state = PeerState(states.COMPLETE, Date.now())
+    this._completed[peer.name] = peer.state
+    delete this._state[peer.name]
+  }
+
+  asJson () {
+    return Object.values(Object.assign({}, this._state)).map((peer) => {
+      var completed = this._completed[peer.name]
+      if (completed) peer.state.lastCompletedDate = completed.message
+      return peer
+    })
+  }
 }
 
 class Sync extends events.EventEmitter {
@@ -50,34 +121,15 @@ class Sync extends events.EventEmitter {
 
     this._activeSyncs = 0
     // track all peer states
-    this._completed = {}
-    this._state = {}
+    this.state = new SyncState()
   }
 
   clearState () {
-    this._state = {}
+    this.state.clear()
   }
 
   peers () {
-    var state = Object.values(Object.assign({}, this._state))
-    return state.map((peer) => {
-      var completed = this._completed[peer.name]
-      if (completed) peer.state.lastCompletedDate = completed.message
-      return peer
-    })
-  }
-
-  _getPeerFromHostPort (host, port) {
-    var res = Object.values(this._state)
-      .filter(function (peer) {
-        // this needs not triple equals, for some reason it fails
-        return peer.port == port && peer.host == host
-      })
-    if (res.length) {
-      return res[0]
-    } else {
-      return null
-    }
+    return this.state.asJson()
   }
 
   replicate ({host, port, filename}, opts) {
@@ -85,16 +137,15 @@ class Sync extends events.EventEmitter {
     var peer
 
     if (host && port) {
-      var emitter = new events.EventEmitter()
-      peer = this._getPeerFromHostPort(host, port)
+      port = parseInt(port)
+      peer = this.state.get(host, port)
       if (!peer) {
-        process.nextTick(function () {
+        var emitter = new events.EventEmitter()
+        process.nextTick(() => {
           emitter.emit('error', new Error('trying to sync to unknown peer'))
         })
         return emitter
       }
-      peer.sync = emitter
-      this._addPeerStateListeners(peer)
       this.replicateNetwork(peer, opts)
     } else if (filename) {
       peer = {
@@ -102,27 +153,12 @@ class Sync extends events.EventEmitter {
         filename,
         sync: new events.EventEmitter()
       }
-      this._addPeerStateListeners(peer)
+      this.state.add(peer)
       this._replicateFromFile(peer, opts)
     } else throw new Error('Requires filename or host and port')
 
-    peer.state = PeerState(REPLICATION_STARTED)
+    this.state.onstart(peer)
     return peer.sync
-  }
-
-  _addPeerStateListeners (peer) {
-    peer.sync.on('progress', (progress) => {
-      peer.state = PeerState(REPLICATION_PROGRESS, progress)
-    })
-
-    peer.sync.on('error', (error) => {
-      peer.state = PeerState(REPLICATION_ERROR, error.message)
-    })
-
-    peer.sync.on('end', () => {
-      peer.state = PeerState(REPLICATION_COMPLETE, Date.now())
-    })
-    this._state[peer.name] = peer
   }
 
   replicateNetwork (peer, opts) {
@@ -265,6 +301,9 @@ class Sync extends events.EventEmitter {
 
     swarm.on('connection', (connection, info) => {
       const peer = WifiPeer(connection, info)
+
+      this.state.add(peer)
+      this.state.onwifi(peer)
       debug('connection', peer)
 
       connection.once('close', onClose)
@@ -275,19 +314,10 @@ class Sync extends events.EventEmitter {
       setTimeout(doSync, 500)
 
       function onClose (err) {
-        if (err) {
-          if (peer.sync) {
-            peer.state = PeerState(REPLICATION_ERROR, err.message)
-            peer.sync.emit('error', err)
-          }
-        }
+        if (err) peer.sync.emit('error', err)
+        if (stream) stream.destroy()
         open = false
-        var peerState = self._state[peer.name]
-        if (peerState && peerState.state) {
-          var topic = peerState.state.topic
-          if (topic === REPLICATION_COMPLETE) self._completed[peer.name] = peerState.state
-          if (topic === WIFI_READY) delete self._state[peer.name]
-        }
+        peer.sync.emit('end')
         self.emit('down', peer)
         debug('down', peer)
       }
@@ -308,26 +338,16 @@ class Sync extends events.EventEmitter {
             self.osm.core.pause()
           }
         })
-        stream.on('progress', function (progress) {
-          if (peer.sync) {
-            peer.state = PeerState(REPLICATION_PROGRESS, progress)
-            peer.sync.emit('progress', progress)
-          }
+        stream.on('progress', (progress) => {
+          if (peer.sync) peer.sync.emit('progress', progress)
         })
         pump(stream, connection, stream, function (err) {
           if (--self._activeSyncs === 0) {
             self.osm.core.resume()
           }
-          if (peer.sync) {
-            if (stream.goodFinish) {
-              peer.state = PeerState(REPLICATION_COMPLETE, Date.now())
-              peer.sync.emit('end')
-            } else {
-              if (!err) err = new Error('sync stream terminated on remote side')
-              peer.state = PeerState(REPLICATION_ERROR, err.message)
-              peer.sync.emit('error', err)
-            }
-          }
+          if (stream.goodFinish) peer.sync.emit('end')
+          else if (!err) err = new Error('sync stream terminated on remote side')
+          if (err) peer.sync.emit('error', err)
           onClose()
         })
       }
@@ -342,8 +362,8 @@ class Sync extends events.EventEmitter {
           accept()
         })
 
+        peer.deviceType = req.deviceType
         peer.name = req.deviceName
-        self._state[peer.name] = peer
         self.emit('peer', peer)
       }
     })
@@ -375,7 +395,6 @@ function WifiPeer (connection, info) {
   // XXX: this is so that each connection has a unique id, even if it's from the same peer.
   info.id = (!info.id || info.id.length !== 12) ? randombytes(6).toString('hex') : info.id
   info.connection = connection
-  info.state = { topic: WIFI_READY }
   return info
 }
 

--- a/sync.js
+++ b/sync.js
@@ -42,6 +42,7 @@ class SyncState {
     this._completed = {}
     this._state = {}
   }
+
   add (peer) {
     peer.sync = new events.EventEmitter()
     var onprogress = (progress) => this.onprogress(peer, progress)
@@ -56,7 +57,7 @@ class SyncState {
     peer.sync.on('error', onerror)
     peer.sync.on('end', onend)
 
-    this._state[peer.name] = peer
+    this._state[peer.id] = peer
   }
 
   get (host, port) {
@@ -93,13 +94,13 @@ class SyncState {
 
   onend (peer) {
     peer.state = PeerState(states.COMPLETE, Date.now())
-    this._completed[peer.name] = peer.state
-    delete this._state[peer.name]
+    this._completed[peer.id] = peer.state
+    delete this._state[peer.id]
   }
 
   asJson () {
     return Object.values(Object.assign({}, this._state)).map((peer) => {
-      var completed = this._completed[peer.name]
+      var completed = this._completed[peer.id]
       if (completed) peer.state.lastCompletedDate = completed.message
       return peer
     })
@@ -149,9 +150,9 @@ class Sync extends events.EventEmitter {
       this.replicateNetwork(peer, opts)
     } else if (filename) {
       peer = {
+        id: filename,
         name: filename,
-        filename,
-        sync: new events.EventEmitter()
+        filename
       }
       this.state.add(peer)
       this._replicateFromFile(peer, opts)

--- a/sync.js
+++ b/sync.js
@@ -99,7 +99,6 @@ class SyncState {
     peer.state = PeerState(states.COMPLETE, Date.now())
     this._completed[peer.id] = Object.assign({}, peer.state)
     delete this._state[peer.id]
-    console.log(this.peers())
   }
 
   peers () {
@@ -306,7 +305,6 @@ class Sync extends events.EventEmitter {
 
     swarm.on('connection', (connection, info) => {
       const peer = WifiPeer(connection, info)
-
       this.state.onwifi(peer)
       debug('connection', peer)
 
@@ -318,10 +316,11 @@ class Sync extends events.EventEmitter {
       setTimeout(doSync, 500)
 
       function onClose (err) {
+        if (!open) return
+        open = false
         if (err) peer.sync.emit('error', err)
         else peer.sync.emit('end')
         if (stream) stream.destroy()
-        open = false
         self.emit('down', peer)
         debug('down', peer)
       }

--- a/test/sync.js
+++ b/test/sync.js
@@ -475,7 +475,7 @@ tape('sync: mobile <-> mobile photos', function (t) {
 })
 
 tape('sync: destroy during sync is reflected in peer state', function (t) {
-  t.plan(11)
+  t.plan(10)
 
   var opts = {api1:{deviceType:'desktop'}, api2:{deviceType:'desktop'}}
   createApis(opts, function (api1, api2, close) {
@@ -528,7 +528,6 @@ tape('sync: destroy during sync is reflected in peer state', function (t) {
 
 tape('sync: 200 photos', function (t) {
   t.plan(14)
-
   var opts = {api1:{deviceType:'desktop'}, api2:{deviceType:'desktop'}}
   createApis(opts, function (api1, api2, close) {
     var pending = 4

--- a/test/sync.js
+++ b/test/sync.js
@@ -471,7 +471,7 @@ tape('sync: mobile <-> mobile photos', function (t) {
   })
 })
 
-tape.only('sync: destroy during sync is reflected in peer state', function (t) {
+tape('sync: destroy during sync is reflected in peer state', function (t) {
   t.plan(11)
 
   var opts = {api1:{deviceType:'desktop'}, api2:{deviceType:'desktop'}}

--- a/test/sync.js
+++ b/test/sync.js
@@ -84,12 +84,17 @@ tape('sync: two servers find eachother', function (t) {
   })
 })
 
-tape.skip('sync: join/leaving swarm is reflected in peer state', function (t) {
+tape('sync: remote peer error/destroyed is reflected in peer state', function (t) {
   createApis(function (api1, api2, close) {
-    var pending = 4
+    var pending = 2
 
     function done () {
-      if (pending) return
+      if (pending === 1) {
+        setTimeout(() => {
+          api2.close()
+        }, 2000)
+      }
+      if (--pending) return
       close()
       t.end()
     }
@@ -98,13 +103,6 @@ tape.skip('sync: join/leaving swarm is reflected in peer state', function (t) {
       api2.sync.listen(function () {
         function check (api) {
           return (peer) => {
-            pending--
-            if (pending === 2) {
-              setTimeout(() => {
-                api1.sync.leave()
-                api2.sync.leave()
-              }, 2000)
-            }
             var peerId = peer.swarmId.toString('hex')
             t.same(peerId, api.sync.swarm.id.toString('hex'), 'api2 id cmp')
             done()
@@ -113,16 +111,7 @@ tape.skip('sync: join/leaving swarm is reflected in peer state', function (t) {
         api1.sync.on('peer', check(api2))
         api2.sync.on('peer', check(api1))
         api1.sync.on('down', function (peer) {
-          var peerId = peer.swarmId.toString('hex')
-          t.same(peerId, api2.sync.swarm.id.toString('hex'), 'api2 id cmp')
           t.same(api1.sync.peers().length, 0)
-          done()
-        })
-        api2.sync.on('down', function (peer) {
-          var peerId = peer.swarmId.toString('hex')
-          t.same(peerId, api1.sync.swarm.id.toString('hex'), 'api1 id cmp')
-          t.same(api2.sync.peers().length, 0)
-          done()
         })
         api1.sync.join()
         api2.sync.join()
@@ -481,6 +470,55 @@ tape('sync: mobile <-> mobile photos', function (t) {
     }
   })
 })
+
+tape.only('sync: destroy during sync is reflected in peer state', function (t) {
+  t.plan(11)
+
+  var opts = {api1:{deviceType:'desktop'}, api2:{deviceType:'desktop'}}
+  createApis(opts, function (api1, api2, close) {
+    var pending = 4
+    var total = 20
+
+    api1.sync.listen()
+    api1.sync.join()
+    api1.sync.on('peer', written.bind(null, null))
+    api2.sync.listen()
+    api2.sync.join()
+    api2.sync.on('peer', written.bind(null, null))
+    helpers.writeBigData(api1, total, written)
+    writeBlob(api2, 'goodbye_world.png', written)
+
+    function written (err) {
+      t.error(err)
+      if (--pending === 0) {
+        t.ok(api1.sync.peers().length > 0, 'api 1 has peers')
+        t.ok(api2.sync.peers().length > 0, 'api 2 has peers')
+        if (api1.sync.peers().length >= 1) {
+          sync(api1.sync.peers()[0])
+        }
+      }
+    }
+
+    function sync (peer) {
+      var syncer = api1.sync.replicate(peer)
+      syncer.on('error', function (err) {
+        t.ok(err)
+        var peers = api1.sync.peers()
+        t.same(peers.length, 1, 'one peer on error')
+        t.same(peers[0].state.topic, 'replication-error', 'replication error!')
+        t.same(peers[0].state.message, err.message, 'got message')
+        close()
+      })
+
+      var totalProgressEvents = 0
+      syncer.on('progress', function (progress) {
+        totalProgressEvents += 1
+        if (totalProgressEvents > 5) api2.sync.close()
+      })
+    }
+  })
+})
+
 
 tape('sync: 200 photos', function (t) {
   t.plan(14)

--- a/test/sync.js
+++ b/test/sync.js
@@ -1,7 +1,6 @@
 var path = require('path')
 var os = require('os')
 var tape = require('tape')
-var tmp = require('tmp')
 var rimraf = require('rimraf')
 
 var helpers = require('./helpers')
@@ -110,8 +109,10 @@ tape('sync: remote peer error/destroyed is reflected in peer state', function (t
         }
         api1.sync.on('peer', check(api2))
         api2.sync.on('peer', check(api1))
-        api1.sync.on('down', function (peer) {
-          t.same(api1.sync.peers().length, 0)
+        api1.sync.on('down', function () {
+          var peers = api1.sync.peers()
+          t.same(peers.length, 1)
+          t.same(peers[0].state.topic, 'replication-complete')
         })
         api1.sync.join()
         api2.sync.join()
@@ -258,7 +259,7 @@ tape('sync: syncfile replication: osm-p2p-syncfile', function (t) {
 })
 
 tape('sync: desktop <-> desktop photos', function (t) {
-  t.plan(16)
+  t.plan(14)
 
   var opts = {api1:{deviceType:'desktop'}, api2:{deviceType:'desktop'}}
   createApis(opts, function (api1, api2, close) {
@@ -270,20 +271,20 @@ tape('sync: desktop <-> desktop photos', function (t) {
 
     api1.sync.listen()
     api1.sync.join()
-    api1.sync.on('peer', written.bind(null, null))
+    api1.sync.once('peer', written.bind(null, null))
     api2.sync.listen()
     api2.sync.join()
-    api2.sync.on('peer', written.bind(null, null))
+    api2.sync.once('peer', written.bind(null, null))
     helpers.writeBigData(api1, total, written)
     writeBlob(api2, 'goodbye_world.png', written)
 
     function written (err) {
       t.error(err)
       if (--pending === 0) {
-        t.ok(api1.sync.peers().length > 0, 'api 1 has peers')
-        t.ok(api2.sync.peers().length > 0, 'api 2 has peers')
-        if (api1.sync.peers().length >= 1) {
-          sync(api1.sync.peers()[0])
+        var peers1 = api1.sync.peers()
+        var peers2 = api2.sync.peers()
+        if (peers1.length >= 1 && peers2.length >= 1) {
+          sync(peers1[0])
         }
       }
     }
@@ -310,8 +311,10 @@ tape('sync: desktop <-> desktop photos', function (t) {
 
         var peers1 = api1.sync.peers()
         var peers2 = api2.sync.peers()
-        t.ok(peers1[0].state, 'api1 peers have progress')
-        t.ok(peers2[0].state, 'api2 peers have progress')
+        t.same(peers1[0].state.topic, 'replication-complete')
+        setTimeout(function () {
+          t.same(peers2[0].state.topic, 'replication-complete')
+        }, 2000)
         var pending = 2
         var expected = mockExpectedMedia(total)
           .concat([
@@ -487,6 +490,9 @@ tape('sync: destroy during sync is reflected in peer state', function (t) {
     api2.sync.on('peer', written.bind(null, null))
     helpers.writeBigData(api1, total, written)
     writeBlob(api2, 'goodbye_world.png', written)
+
+    api1.on('error', console.error)
+    api2.on('error', console.error)
 
     function written (err) {
       t.error(err)


### PR DESCRIPTION
* We were setting listeners differently depending on if you're the initiator of wifi sync or not, now that should be symmetric.
* Refactored state handling to its own class
* Tracks peers by id instead of name. Not entirely sure on the implications for UI here but we'll figure it out.. 
