### PR TITLE
fix: Wait for pause to complete before starting sync

### DIFF
--- a/sync.js
+++ b/sync.js
@@ -352,8 +352,9 @@ class Sync extends events.EventEmitter {
         })
         stream.once('sync-start', function () {
           if (++self._activeSyncs === 1) {
-            self.osm.core.pause()
-            peer.sync.emit('sync-start')
+            self.osm.core.pause(function () {
+              peer.sync.emit('sync-start')
+            })
           }
         })
         stream.on('progress', (progress) => {


### PR DESCRIPTION
I didn't fully test this, but index is not actually paused until at least the next tick, and sometimes after the index batch has completed, so we should wait for the callback before starting sync.