### PR TITLE
Fail tests if media is not created

### DIFF
--- a/test/helpers.js
+++ b/test/helpers.js
@@ -71,12 +71,14 @@ function writeBigData (mapeo, n, cb) {
 
       if (tasks.length === n) {
         run(tasks, 10, function (err) {
+          if (err) return cb(err)
           mapeo.media.list(function (_, files) {
             if (files.length !== n * 3) {
               console.log(`ERROR: not enough images were created! (${files.length} / ${n*3}) have:`)
               files.forEach(f => console.log(f))
+              return cb(new Error('Error creating images, not enough were created'))
             }
-            cb(err)
+            cb()
           })
         })
       }


### PR DESCRIPTION
Fail tests if images were not created correctly in test setup. Caused by #33.