### PR TITLE
feat: Add peer-update event to listen for sync events from non-sync initiator

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,13 @@ A peer can have the following properties:
 
 Emitted when a new wifi peer connection is discovered.
 
+## sync.on('peer-update', peer)
+
+**Experimental**: Emitted when a peer state is updated (e.g. from a progress
+event). Is not (yet) guaranteed to run on every peer update event equally on
+both sides of a sync stream but does provide a way to avoid polling
+`sync.peers()`.
+
 ### var ev = sync.replicate(target[, opts])
 
 `peer` is an object with properties `host`, `port`, and `name` **or** an object

--- a/sync.js
+++ b/sync.js
@@ -406,6 +406,14 @@ class Sync extends events.EventEmitter {
         // the other side just have accepted & wants to start.
         stream.once('accepted', function () {
           self.state.addProgressEventListeners(peer)
+          // This is a hacky way to get the updates we need on the client. This
+          // event needs to run after the `onprogress` event handler that is
+          // attached in the line above, which updates the peer progress state.
+          // The client listens for peer events so it can update the UI, even
+          // when sync was initiated from the other side. TODO: This event
+          // emitter is not removed when the connection closes, but that should
+          // be ok for now.
+          peer.sync.on('progress', () => self.emit('peer-update', peer))
           accept()
         })
 


### PR DESCRIPTION
There was no way to detect sync events initiated by "the other side". This adds a `peer-update` event on mapeo.sync which will be emitted (most) times a peer is updated.

@noffle this is not an ideal solution - it's really hard to ensure that it is emitted on every single peer update and also correctly remove the events - but with this PR I was able to correctly show sync progress _on both sides_ of a sync in the client UI.

I have some thoughts about how to improve this interface for API consumers that makes it easier to draw the UI based on sync state. I'll write those in another issue.