### PR TITLE
Discovery key fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,9 @@ Broadcast and listen on the local network for peers. `cb` is called once the ser
 
 Join the swarm and begin making introductory connections with other peers.
 
-Optionally accepts a `projectKey` string. This will swarm only with peers that have also passed in the same `projectKey`.
+Optionally accepts a `projectKey` which must be a 32-byte buffer or a string hex encoding of a 32-byte buffer. This will swarm only with peers that have also passed in the same `projectKey`.
+
+An invalid `projectKey` will throw an error.
 
 ### sync.leave([projectKey])
 
@@ -132,7 +134,9 @@ Leave the swarm and no longer be discoverable by other peers. Any currently
 open connections are kept until the swarm is destroyed (using `close` or
 `destroy`).
 
-Optionally accepts a `projectKey` string, to leave the same swarm you joined.
+Optionally accepts a `projectKey` which must be a 32-byte buffer or a string hex encoding of a 32-byte buffer, to leave the same swarm you joined.
+
+An invalid `projectKey` will throw an error.
 
 ### sync.close(cb)
 


### PR DESCRIPTION
The changes in 097deee and 98fffb8 forced projectKey to be a hex string that must be 32-bytes long. This reverts the change so that projectKey can be any string of arbitrary length.

The [implementation of `discoveryKey()`](https://github.com/mafintosh/hypercore-crypto/blob/master/index.js#L84) in `hypercore-crypto` uses the input as the `key` argument for [`crypto_generichash`](https://github.com/sodium-friends/sodium-native#crypto_generichashoutput-input-key). This restricts the projectKey to be within `crypto_generichash_KEYBYTES_MIN` - `crypto_generichash_KEYBYTES_MAX` (16-bytes - 64-bytes on my machine). This doesn't matter for hypercore, since the `publicKey` (32-bytes long) is always used as the input for the discovery key (see https://github.com/mafintosh/hypercore-crypto/issues/4) but for our use-case it is helpful that `projectKey` can be of arbitrary length, so we can have human-readable project ids in the short-term (whilst we define projectId in presets.json) and we can always start using 32-bit public keys in the future for increased entropy without needing to change the discovery key generation.

**This might also need changing in mapeo-web** although I'm not sure it uses `discoveryKey()` in the same way there. @noffle?

This implementation uses a 32-byte hash of `mapeo` as the hash key, since the [sodium docs](https://download.libsodium.org/doc/hashing/generic_hashing#usage) suggest that:

> the key can be used to make sure that different applications generate different fingerprints even if they process the same data.

This change is also helpful because we have downstream tests that use arbitrary-length projectKey and [those tests](https://github.com/digidem/mapeo-server/blob/master/test/sync.js#L29) were breaking with mapeo-core v8.