### PR TITLE
Discovery key fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,9 @@ Broadcast and listen on the local network for peers. `cb` is called once the ser
 
 Join the swarm and begin making introductory connections with other peers.
 
-Optionally accepts a `projectKey` string. This will swarm only with peers that have also passed in the same `projectKey`.
+Optionally accepts a `projectKey` which must be a 32-byte buffer or a string hex encoding of a 32-byte buffer. This will swarm only with peers that have also passed in the same `projectKey`.
+
+An invalid `projectKey` will throw an error.
 
 ### sync.leave([projectKey])
 
@@ -132,7 +134,9 @@ Leave the swarm and no longer be discoverable by other peers. Any currently
 open connections are kept until the swarm is destroyed (using `close` or
 `destroy`).
 
-Optionally accepts a `projectKey` string, to leave the same swarm you joined.
+Optionally accepts a `projectKey` which must be a 32-byte buffer or a string hex encoding of a 32-byte buffer, to leave the same swarm you joined.
+
+An invalid `projectKey` will throw an error.
 
 ### sync.close(cb)
 

--- a/test/sync.js
+++ b/test/sync.js
@@ -85,7 +85,7 @@ tape('sync: two servers find each other with default sync key', function (t) {
   })
 })
 
-tape('sync: two servers find each other with default same projectKey', function (t) {
+tape('sync: two servers find each other with same projectKey', function (t) {
   createApis(function (api1, api2, close) {
     var pending = 2
 

--- a/test/sync.js
+++ b/test/sync.js
@@ -149,6 +149,7 @@ tape('sync: trying to sync with an invalid projectKey throws', function (t) {
     api1.sync.listen(function () {
       api2.sync.listen(function () {
         t.throws(() => api1.sync.join('invalid key'), 'throws on invalid key')
+        close()
         t.end()
       })
     })


### PR DESCRIPTION
Re-work of #58. This adds tests, improves docs and throws instead of failing silently if an invalid projectKey is passed.