### PR TITLE
use discovery key in syncfile

### DIFF
--- a/sync.js
+++ b/sync.js
@@ -269,6 +269,7 @@ class Sync extends events.EventEmitter {
     })
 
     function sync () {
+      const discoKey = discoveryKey(opts.projectKey)
       const syncfile = new Syncfile(filename, os.tmpdir())
       syncfile.ready(function (err) {
         if (err) return onerror(err)
@@ -277,8 +278,8 @@ class Sync extends events.EventEmitter {
           if (data && data['p2p-db'] && data['p2p-db'] !== 'kappa-osm') {
             return onerror(new Error('trying to sync this kappa-osm database with a ' + data['p2p-db'] + ' database!'))
           }
-          if (data && data.projectKey && opts.projectKey && data.projectKey !== opts.projectKey) {
-            return onerror(new Error(`trying to sync two different projects (us=${opts.projectKey}) (syncfile=${data.projectKey})`))
+          if (data && data.discoveryKey && opts.projectKey && data.discoveryKey !== discoKey) {
+            return onerror(new Error(`trying to sync two different projects (us=${discoKey}) (syncfile=${data.discoveryKey})`))
           }
           start()
         })
@@ -302,7 +303,7 @@ class Sync extends events.EventEmitter {
             var userdata = {
               'p2p-db': 'kappa-osm'
             }
-            if (opts.projectKey) userdata.projectKey = opts.projectKey
+            if (opts.projectKey) userdata.discoveryKey = discoKey
             syncfile.userdata(userdata, function () {
               syncfile.close(onend.bind(null, error))
             })

--- a/test/sync.js
+++ b/test/sync.js
@@ -357,13 +357,16 @@ tape('sync: syncfile replication: osm-p2p-syncfile', function (t) {
 tape('sync: try to sync two different projectKey syncfiles together', function (t) {
   t.plan(2)
 
+  var key1 = crypto.randomBytes(32).toString('hex')
+  var key2 = crypto.randomBytes(32).toString('hex')
+
   var tmpfile = path.join(os.tmpdir(), 'sync1-' + Math.random().toString().substring(2))
   var syncfile = new itar(tmpfile)
-  syncfile.userdata({syncfile: { 'p2p-db': 'kappa-osm', projectKey: 'bar' } }, start)
+  syncfile.userdata({syncfile: { 'p2p-db': 'kappa-osm', discoveryKey: key1} }, start)
 
   function start () {
     createApis({api1:{writeFormat: 'osm-p2p-syncfile'}}, function (api1, api2, close) {
-      api1.sync.replicate({filename: tmpfile}, {projectKey: 'foo'})
+      api1.sync.replicate({filename: tmpfile}, {projectKey: key2})
         .once('end', function () {
           t.fail()
         })
@@ -386,6 +389,7 @@ tape('sync: syncfile /wo projectKey, api with projectKey set', function (t) {
     var pending = 2
     var lastProgress
     var obs = {lat: 1, lon: 2, type: 'observation'}
+    var projectKey = crypto.randomBytes(32).toString('hex')
 
     api1.osm.create(obs, written)
     var ws = api1.media.createWriteStream('foo.txt')
@@ -397,7 +401,7 @@ tape('sync: syncfile /wo projectKey, api with projectKey set', function (t) {
       t.error(err, res ? 'osm data written ok' : 'media data written ok')
       if (res) id = res.id
       if (--pending === 0) {
-        api1.sync.replicate({filename: tmpfile}, {projectKey:'quux'})
+        api1.sync.replicate({filename: tmpfile}, {projectKey:projectKey})
           .once('end', syncfileWritten)
           .once('error', syncfileWritten)
           .on('progress', function (progress) {


### PR DESCRIPTION
This has syncfiles store the discovery key instead of the project key in
syncfiles, preventing the project key from being leaked by anyone who
intercepts the syncfile. This is NOT a breaking change, since syncfiles
without the new 'discoveryKey' userdata field set can still be synced to
by anybody.