### PR TITLE
Improve sync total accuracy

### DIFF
--- a/lib/db-sync-progress.js
+++ b/lib/db-sync-progress.js
@@ -1,12 +1,12 @@
 var eos = require('end-of-stream')
 
-module.exports = function (isInitiator, db, opts) {
-  var multifeed = db.osm.core._logs
+module.exports = function (isInitiator, {osm}, opts) {
+  var multifeed = osm.core._logs
+  var sofar = 0
+  var total = null
 
   var stream = multifeed.replicate(isInitiator, opts)
 
-  var feeds = []
-  var progress = {}
   var listeners = []
   var pendingFeeds = 0
 
@@ -18,9 +18,14 @@ module.exports = function (isInitiator, db, opts) {
       multifeed.removeListener('feed', onFeed)
       listeners.forEach(function (l) {
         l.feed.removeListener('download', l.listener)
+        l.feed.removeListener('upload', l.listener)
       })
     })
   })
+
+  stream.setTotals = function (down, up) {
+    total = down + up
+  }
 
   return stream
 
@@ -28,25 +33,22 @@ module.exports = function (isInitiator, db, opts) {
     ++pendingFeeds
     feed.ready(function () {
       --pendingFeeds
-      feeds.push(feed)
-      updateFeed(feed)
     })
-    feed.on('download', onDownload)
-    function onDownload () {
-      updateFeed(feed)
+    feed.on('download', onProgress)
+    feed.on('upload', onProgress)
+    function onProgress () {
+      sofar++
+      onUpdate(feed)
     }
-    listeners.push({ feed: feed, listener: onDownload })
+    listeners.push({ feed: feed, listener: onProgress })
   }
 
-  function updateFeed (feed) {
-    progress[feed.key.toString('hex')] = feed.downloaded(0, feed.length)
-    var total = feeds.reduce(function (acc, feed) { return acc + feed.length }, 0)
-    var sofar = feeds.reduce(function (acc, feed) { return acc + feed.downloaded(0, feed.length) }, 0)
+  function onUpdate (feed) {
     if (!allFeedsReady()) return
     stream.emit('progress', sofar, total)
   }
 
   function allFeedsReady () {
-    return pendingFeeds === 0 && feeds.every(function (feed) { return feed.readable })
+    return pendingFeeds === 0 && sofar > 0 && total !== null
   }
 }

--- a/lib/sync-stream.js
+++ b/lib/sync-stream.js
@@ -5,14 +5,22 @@ var handshake = require('handshake-stream')
 var multiplex = require('multiplex')
 var pump = require('pump')
 var progressSync = require('./db-sync-progress')
+var util = require('./util')
 
 function sync (isInitiator, db, media, opts) {
+  const localDbState = util.dbState(db)
+  let expectedDownloads, expectedUploads
+
   var payload = {
     id: opts.id,
     protocolVersion: opts.protocolVersion || 1,
     deviceType: opts.deviceType,
     deviceName: opts.deviceName,
+    state: {
+      db: localDbState
+    }
   }
+
   // handshake protocol
   var accepted = false
 
@@ -21,6 +29,11 @@ function sync (isInitiator, db, media, opts) {
   var hand = handshake(m, payload, function (req, accept) {
     if (req.protocolVersion === opts.protocolVersion) {
       remoteDeviceType = req.deviceType
+
+      expectedDownloads = util.getExpectedDownloadEvents(localDbState, req.state.db)
+      expectedUploads = util.getExpectedUploadEvents(localDbState, req.state.db)
+      r.setTotals(expectedDownloads, expectedUploads)
+
       if (opts.handshake) opts.handshake(req, onaccept); else onaccept()
     } else {
       process.nextTick(function () {

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,0 +1,31 @@
+module.exports = {
+  dbState,
+  mfState,
+  getExpectedDownloadEvents,
+  getExpectedUploadEvents
+}
+
+function dbState (db) {
+  return mfState(db.core._logs)
+}
+
+function mfState (mf) {
+  let state = {}
+  mf.feeds().forEach(f => {
+    state[f.key.toString('hex')] = f.length
+  })
+  return state
+}
+
+function getExpectedDownloadEvents (local, remote) {
+  return Object.entries(remote).reduce((accum, [key,length]) => {
+    if (!local[key]) accum += length
+    else if (local[key] < length) accum += length - local[key]
+    return accum
+  }, 0)
+}
+
+function getExpectedUploadEvents (local, remote) {
+  return getExpectedDownloadEvents(remote, local)
+}
+

--- a/sync.js
+++ b/sync.js
@@ -254,7 +254,7 @@ class Sync extends events.EventEmitter {
 
   /**
    * Replicate from a given file. Use `replicate` instead.
-   * @param  {String}   peer    A peer.
+   * @param  {{filename:string, sync?:EventEmitter}} peer    A peer.
    * @return {EventEmitter}     Listen to 'error', 'end' and 'progress' events
    */
   replicateFromFile (peer, opts) {

--- a/test/db-sync-progress.js
+++ b/test/db-sync-progress.js
@@ -63,9 +63,11 @@ test('db-sync-progress: 6 entries', function (t) {
 
       var a = sync(true, db1, { live: false })
       var b = sync(false, db2, { live: false })
+      a.setTotals(3, 3)
+      b.setTotals(3, 3)
 
-      var eventsLeftA = 5
-      var eventsLeftB = 5
+      var eventsLeftA = 6
+      var eventsLeftB = 6
       a.on('progress', function (sofar, total) {
         eventsLeftA--
       })
@@ -98,6 +100,8 @@ test('db-sync-progress: 200 entries', function (t) {
 
       var a = sync(true, db1, { live: false })
       var b = sync(false, db2, { live: false })
+      a.setTotals(100, 100)
+      b.setTotals(100, 100)
 
       var sofarA, totalA
       var sofarB, totalB

--- a/test/sync-progress.js
+++ b/test/sync-progress.js
@@ -149,7 +149,7 @@ tape('sync-progress: database progress total is stable', function (t) {
   })
 })
 
-tape.skip('sync-progress: database sync progress restarts at 0/N per sync', function (t) {
+tape('sync-progress: database sync progress restarts at 0/N per sync', function (t) {
   t.plan(5)
 
   var setup = {
@@ -174,7 +174,7 @@ tape.skip('sync-progress: database sync progress restarts at 0/N per sync', func
       t.error(err)
 
       syncer.once('progress', function (p) {
-        t.same(p.db.sofar, 0, 'progress: 0 elements sofar')
+        t.same(p.db.sofar, 1, 'progress: 1 element sofar')
         t.same(p.db.total, 10, 'progress: 10 elements total')
       })
       syncer.once('error', function (err) {
@@ -189,7 +189,7 @@ tape.skip('sync-progress: database sync progress restarts at 0/N per sync', func
   })
 })
 
-tape.skip('sync-progress: database sync progress includes uploads', function (t) {
+tape('sync-progress: database sync progress includes uploads', function (t) {
   t.plan(4)
 
   var setup = {
@@ -214,7 +214,7 @@ tape.skip('sync-progress: database sync progress includes uploads', function (t)
       t.error(err)
 
       syncer.once('progress', function (p) {
-        t.same(p.db.total, 10, 'db progress total is correct')
+        t.same(p.db.total, 20, 'db progress total is correct')
       })
       syncer.once('error', function (err) {
         t.error(err)
@@ -280,7 +280,7 @@ tape('sync-progress: correct totals when receiving multiple remote feeds', funct
   })
 })
 
-tape.skip('sync-progress: mix of uploading cores & downloading cores', function (t) {
+tape('sync-progress: mix of uploading cores & downloading cores', function (t) {
   t.plan(5)
 
   var setup = {


### PR DESCRIPTION
This includes feed length information in the sync handshake, so that both sides
can determine how many new hypercore blocks they expect to download and upload
respectively.

This also un-`skip`s some tests in `test/sync-progress.js`, now that upload
progress is being tracked.