### PR TITLE
refactor: expose more testable errors with codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Join the swarm and begin making introductory connections with other peers.
 
 Optionally accepts a `projectKey` which must be a 32-byte buffer or a string hex encoding of a 32-byte buffer. This will swarm only with peers that have also passed in the same `projectKey`.
 
-An invalid `projectKey` will throw an error.
+An invalid `projectKey` will throw a `ERR_MALFORMED_PROJECT_KEY` error.
 
 ### sync.leave([projectKey])
 
@@ -136,7 +136,7 @@ open connections are kept until the swarm is destroyed (using `close` or
 
 Optionally accepts a `projectKey` which must be a 32-byte buffer or a string hex encoding of a 32-byte buffer, to leave the same swarm you joined.
 
-An invalid `projectKey` will throw an error.
+An invalid `projectKey` will throw a `ERR_MALFORMED_PROJECT_KEY` error.
 
 ### sync.close(cb)
 
@@ -190,6 +190,23 @@ event or returned on the `peers()` method.
 If you want to replicate with a peer that is not discovered yet, but you have
 the host and port, we haven't made this easy at the moment. The code is written
 internally but not exposed via a public API. PRs welcome.
+
+### Sync errors
+
+Various subclasssed `Error`s are exposed by this module, to make it easier to
+check for specific failure modes. They all use the `.code` and `.message` fields.
+
+These are the supported error `code`s:
+
+- `ERR_PEER_NOT_FOUND`: the peer (network or file) could not be located / doesn't exist
+- `ERR_DIFF_PROJECT_KEYS`: you're trying to sync with a peer that's using a different project
+- `ERR_PREMATURE_SYNC`: you tried to sync with a peer before the initial handshake finished (this shouldn't happen)
+- `ERR_UNSUPPORTED_SYNCFILE_FORMAT`: the syncfile's format is incompatible with your version of mapeo-core
+- `ERR_CONNECTION_LOST`: the connection to the network peer was lost
+- `ERR_SYNC`: general sync error
+- `ERR_MALFORMED_PROJECT_KEY`: the project key specified isn't a 32-byte hexstring or `Buffer`
+
+Constants for these codes are accessible under `require('@mapeo/core/lib/errors')`.
 
 ## Importer API (expertimental)
 

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,0 +1,82 @@
+class MapeoError extends Error {
+  constructor (code, message, innerError) {
+    super(message)
+    this.code = code
+    this.message = message
+    this.err = innerError
+  }
+}
+
+const ERR_PEER_NOT_FOUND              = 'ERR_PEER_NOT_FOUND'
+const ERR_DIFF_PROJECT_KEYS           = 'ERR_DIFF_PROJECT_KEYS'
+const ERR_PREMATURE_SYNC              = 'ERR_PREMATURE_SYNC'
+const ERR_UNSUPPORTED_SYNCFILE_FORMAT = 'ERR_UNSUPPORTED_SYNCFILE_FORMAT'
+const ERR_CONNECTION_LOST             = 'ERR_CONNECTION_LOST'
+const ERR_SYNC                        = 'ERR_SYNC'
+const ERR_MALFORMED_PROJECT_KEY       = 'ERR_MALFORMED_PROJECT_KEY'
+
+class PeerNotFoundError extends MapeoError {
+  constructor (innerError) {
+    super(ERR_PEER_NOT_FOUND, 'peer was not found', innerError)
+  }
+}
+
+class IncompatibleProjectsError extends MapeoError {
+  constructor (innerError) {
+    super(ERR_DIFF_PROJECT_KEYS, 'remote project key is different than ours', innerError)
+  }
+}
+
+class PrematureSyncError extends MapeoError {
+  constructor (innerError) {
+    super(ERR_PREMATURE_SYNC,  'sync started before handshake finished', innerError)
+  }
+}
+
+class UnsupportedSyncfileError extends MapeoError {
+  constructor (format, innerError) {
+    super(ERR_UNSUPPORTED_SYNCFILE_FORMAT, 'syncfile type is not supported ('+format+')', innerError)
+  }
+}
+
+class ConnectionLostError extends MapeoError {
+  constructor (innerError) {
+    super(ERR_CONNECTION_LOST, 'peer network connection lost', innerError)
+  }
+}
+
+class SyncError extends MapeoError {
+  constructor (message, innerError) {
+    super(ERR_SYNC, message || 'sync failed', innerError)
+  }
+}
+
+class MalformedProjectKeyError extends MapeoError {
+  constructor (key, innerError) {
+    super(ERR_MALFORMED_PROJECT_KEY, 'project key is malformed', innerError)
+    this.key = truncateKey(key)
+  }
+}
+
+module.exports = {
+  PeerNotFoundError,
+  IncompatibleProjectsError,
+  PrematureSyncError,
+  UnsupportedSyncfileError,
+  ConnectionLostError,
+  SyncError,
+  MalformedProjectKeyError,
+  ERR_PEER_NOT_FOUND,
+  ERR_DIFF_PROJECT_KEYS,
+  ERR_PREMATURE_SYNC,
+  ERR_UNSUPPORTED_SYNCFILE_FORMAT,
+  ERR_CONNECTION_LOST,
+  ERR_SYNC,
+  ERR_MALFORMED_PROJECT_KEY
+}
+
+function truncateKey (key) {
+  if (Buffer.isBuffer(key)) key = key.toString('hex')
+  if (typeof key === 'string') return key.substring(0,5) + '..'
+  else return ''
+}

--- a/test/sync.js
+++ b/test/sync.js
@@ -3,6 +3,7 @@ var os = require('os')
 var tape = require('tape')
 var itar = require('indexed-tarball')
 var crypto = require('crypto')
+var errors = require('../lib/errors')
 
 var helpers = require('./helpers')
 
@@ -233,7 +234,7 @@ tape('sync: bad syncfile replication: osm-p2p-syncfile', function (t) {
         })
         .once('error', function (err) {
           t.ok(err)
-          t.same(err.message, 'trying to sync this kappa-osm database with a hyperlog database!')
+          t.same(err.code, errors.ERR_UNSUPPORTED_SYNCFILE_FORMAT)
         })
         .on('progress', function (progress) {
           t.fail()
@@ -327,7 +328,7 @@ tape('sync: try to sync two different projectKey syncfiles together', function (
         })
         .once('error', function (err) {
           t.ok(err)
-          t.ok(/trying to sync two different projects/.test(err.message), 'expected error message')
+          t.equals(err.code, errors.ERR_DIFF_PROJECT_KEYS, 'expected error message')
         })
         .on('progress', function (progress) {
           t.fail()


### PR DESCRIPTION
This creates a `MapeoError` subclassed from `Error`, and documented error codes for the various high-level types of failures the module exposes.

Fixes #77 