### PR TITLE
v8 peer fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,9 +138,11 @@ Optionally accepts a `projectKey` which must be a 32-byte buffer or a string hex
 
 An invalid `projectKey` will throw an error.
 
-### sync.close(cb)
+### sync.close([cb])
 
-Unannounces the sync service & cleans up the underlying UDP socket. `cb` is called once this is complete.
+Unannounces the sync service & cleans up the underlying UDP socket. Optionally accepts `cb` which is called once this is complete. 
+
+Emits `close` event.
 
 ### sync.peers()
 

--- a/README.md
+++ b/README.md
@@ -150,13 +150,12 @@ Fetch a list of the current sync peers that have been found thus far.
 
 A peer can have the following properties:
 
-* `name`: a human-readable identifier for the peer (e.g., hostname)
-* `connection`: The open connection to this peer. Can be closed manually to
-  stop any data transfer.
-* `host`: the ip
-* `port`: the port
-* `type`: 'wifi' or 'file'
-* `deviceType`: either `mobile` or `desktop`, if `type == 'wifi'`
+* `name` (string): a human-readable identifier for the peer (e.g., hostname)
+* `connected` (boolean): whether the peer is currently connected to you
+* `host` (string): the ip
+* `port` (number): the port
+* `type` (string): 'wifi' or 'file'
+* `deviceType` (string): either `mobile` or `desktop`, if `type == 'wifi'`
 
 ### sync.on('peer', peer)
 

--- a/index.js
+++ b/index.js
@@ -245,7 +245,11 @@ class Mapeo extends events.EventEmitter {
   }
 
   close (cb) {
-    this.sync.close(cb)
+    this.osm.core.pause(() => {
+      this.osm.core._logs.close(() => {
+        this.sync.close(cb)
+      })
+    })
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -247,7 +247,11 @@ class Mapeo extends events.EventEmitter {
   close (cb) {
     this.sync.close(() => {
       this.osm.core.pause(() => {
-        this.osm.core._logs.close(cb)
+        // This calls multifeed.close() which closes the hypercore feeds
+        this.osm.core._logs.close(() => {
+          this.emit('close')
+          if (cb) cb()
+        })
       })
     })
   }

--- a/index.js
+++ b/index.js
@@ -245,9 +245,9 @@ class Mapeo extends events.EventEmitter {
   }
 
   close (cb) {
-    this.osm.core.pause(() => {
-      this.osm.core._logs.close(() => {
-        this.sync.close(cb)
+    this.sync.close(() => {
+      this.osm.core.pause(() => {
+        this.osm.core._logs.close(cb)
       })
     })
   }

--- a/lib/sync-stream.js
+++ b/lib/sync-stream.js
@@ -31,6 +31,14 @@ function sync (db, media, opts) {
       if (accepted) return
       accepted = true
       if (!err) {
+        // XXX: Using pipe() here instead of pump because of a bug in multifeed
+        // (probably) where both sides of the stream aren't being closed properly
+        // on end-of-stream.
+        r.pipe(p2p).pipe(r)
+        r.once('error', function (err) {
+          hand.emit('error', err)
+        })
+
         m1 = bsync(media, { filter: mediaSyncFilter })
         m1.on('progress', function (sofar, total) {
           progress.media.sofar = sofar
@@ -63,13 +71,6 @@ function sync (db, media, opts) {
   })
 
   var p2p = m.createSharedStream('p2p')
-  // XXX: Using pipe() here instead of pump because of a bug in multifeed
-  // (probably) where both sides of the stream aren't being closed properly
-  // on end-of-stream.
-  r.pipe(p2p).pipe(r)
-  r.once('error', function (err) {
-    hand.emit('error', err)
-  })
 
   var remoteDeviceType
   function mediaSyncFilter (filename) {

--- a/lib/sync-stream.js
+++ b/lib/sync-stream.js
@@ -45,7 +45,6 @@ function sync (db, media, opts) {
           progress.media.total = total
           hand.emit('progress', progress)
         })
-        console.log('shared stream')
         var m1s = m.createSharedStream('media')
         pump(m1, m1s, m1, function (err) {
           if (err) hand.emit('error', err)

--- a/sync.js
+++ b/sync.js
@@ -52,7 +52,6 @@ function PeerState (topic, message, other) {
 
 class SyncState {
   constructor () {
-    this._completed = {}
     this._state = {}
   }
 
@@ -95,6 +94,10 @@ class SyncState {
     return peer.state.topic === ReplicationState.COMPLETE || peer.state.topic === ReplicationState.ERROR
   }
 
+  _iscomplete (peer) {
+    return peer.state.topic === ReplicationState.COMPLETE
+  }
+
   onwifi (peer) {
     peer.state = PeerState(ReplicationState.WIFI_READY)
     this.add(peer)
@@ -129,23 +132,14 @@ class SyncState {
     if (this._isclosed(peer)) return
     if (peer.started) {
       peer.state = PeerState(ReplicationState.COMPLETE, Date.now())
-      this._completed[peer.name] = Object.assign({}, peer)
     }
-    delete this._state[peer.id]
   }
 
   peers () {
-    var self = this
-    var peers = []
-    Object.values(this._state).map((peer) => {
-      var completed = self._completed[peer.name]
-      if (completed) peer.state.lastCompletedDate = completed.state.message
-      peers.push(peer)
+    return Object.values(this._state).map((peer) => {
+      if (this._iscomplete(peer)) peer.state.lastCompletedDate = peer.state.message
+      return peer
     })
-    Object.values(this._completed).map((peer) => {
-      if (!(peers.find((p) => p.name === peer.name))) peers.push(peer)
-    })
-    return peers
   }
 }
 

--- a/sync.js
+++ b/sync.js
@@ -232,7 +232,6 @@ class Sync extends events.EventEmitter {
   listen (cb) {
     if (!cb) cb = () => {}
     if (this.swarm && !this._destroyingSwarm) {
-      console.error('Swarm already exists.')
       return process.nextTick(cb)
     }
 

--- a/sync.js
+++ b/sync.js
@@ -63,6 +63,7 @@ class SyncState {
 
   init (peer) {
     peer.started = false
+    peer.connected = true
     peer.sync = new events.EventEmitter()
     var onsync = () => this.onsync(peer)
     var onerror = (error) => this.onerror(peer, error)
@@ -142,6 +143,7 @@ class SyncState {
 
   onerror (peer, error) {
     if (this._isclosed(peer)) return
+    peer.connected = false
     const errorMetadata = {}
     multifeedErrorProps.forEach(key => {
       if (error[key]) errorMetadata[key] = error[key]
@@ -151,6 +153,7 @@ class SyncState {
 
   onend (peer) {
     if (this._isclosed(peer)) return
+    peer.connected = false
     if (peer.started) {
       peer.state = PeerState(ReplicationState.COMPLETE, Date.now())
     }

--- a/sync.js
+++ b/sync.js
@@ -105,7 +105,8 @@ class SyncState {
   }
 
   addWifiPeer (connection, info) {
-    let peer = this._state[info.id]
+    const peerId = info.id.toString('hex')
+    let peer = this._state[peerId]
     if (!peer) {
       peer = WifiPeer(connection, info)
       this._add(peer)

--- a/sync.js
+++ b/sync.js
@@ -455,8 +455,8 @@ function isGzipFile (filepath, cb) {
 
 function WifiPeer (connection, info) {
   info.type = 'wifi'
-  info.swarmId = info.swarmId || info.id
   info.connection = connection
+  info.swarmId = info.id // XXX: not used; for backwards compatibility
   return info
 }
 

--- a/sync.js
+++ b/sync.js
@@ -364,7 +364,7 @@ class Sync extends events.EventEmitter {
 
   _swarm (id) {
     var self = this
-    var swarm = Swarm({id: id})
+    var swarm = Swarm(Object.assign(this.opts, {id: id}))
 
     swarm.on('connection', (connection, info) => {
       const peer = WifiPeer(connection, info)

--- a/sync.js
+++ b/sync.js
@@ -58,17 +58,17 @@ class SyncState {
 
   add (peer) {
     peer.sync = new events.EventEmitter()
-    var onstart = () => this.onstart(peer)
+    var onsync = () => this.onsync(peer)
     var onerror = (error) => this.onerror(peer, error)
     var onend = () => {
       this.onend(peer)
-      peer.sync.removeListener('sync-start', onstart)
+      peer.sync.removeListener('sync-start', onsync)
       peer.sync.removeListener('end', onend)
       peer.sync.removeListener('error', onerror)
       if (peer.sync.onprogress) peer.sync.removeListener('progress', peer.sync.onprogress)
     }
 
-    peer.sync.on('sync-start', onstart)
+    peer.sync.on('sync-start', onsync)
     peer.sync.on('error', onerror)
     peer.sync.on('end', onend)
     this._state[peer.id] = peer
@@ -101,12 +101,12 @@ class SyncState {
   }
 
   onfile (peer) {
-    this.onstart(peer)
+    this.onsync(peer)
     this.add(peer)
     this.addProgressEventListeners(peer)
   }
 
-  onstart (peer) {
+  onsync (peer) {
     peer.started = true
     peer.state = PeerState(states.STARTED)
   }

--- a/sync.js
+++ b/sync.js
@@ -36,7 +36,7 @@ const DEFAULT_INTERNET_DISCO = Object.assign(
   }
 )
 
-const states = {
+const ReplicationState = {
   WIFI_READY: 'replication-wifi-ready',
   PROGRESS: 'replication-progress',
   COMPLETE: 'replication-complete',
@@ -92,11 +92,11 @@ class SyncState {
   }
 
   _isclosed (peer) {
-    return peer.state.topic === states.COMPLETE || peer.state.topic === states.ERROR
+    return peer.state.topic === ReplicationState.COMPLETE || peer.state.topic === ReplicationState.ERROR
   }
 
   onwifi (peer) {
-    peer.state = PeerState(states.WIFI_READY)
+    peer.state = PeerState(ReplicationState.WIFI_READY)
     this.add(peer)
   }
 
@@ -108,12 +108,12 @@ class SyncState {
 
   onsync (peer) {
     peer.started = true
-    peer.state = PeerState(states.STARTED)
+    peer.state = PeerState(ReplicationState.STARTED)
   }
 
   onprogress (peer, progress) {
     if (this._isclosed(peer)) return
-    peer.state = PeerState(states.PROGRESS, progress)
+    peer.state = PeerState(ReplicationState.PROGRESS, progress)
   }
 
   onerror (peer, error) {
@@ -122,13 +122,13 @@ class SyncState {
     multifeedErrorProps.forEach(key => {
       if (error[key]) errorMetadata[key] = error[key]
     })
-    peer.state = PeerState(states.ERROR, error ? error.toString() : 'Error', errorMetadata)
+    peer.state = PeerState(ReplicationState.ERROR, error ? error.toString() : 'Error', errorMetadata)
   }
 
   onend (peer) {
     if (this._isclosed(peer)) return
     if (peer.started) {
-      peer.state = PeerState(states.COMPLETE, Date.now())
+      peer.state = PeerState(ReplicationState.COMPLETE, Date.now())
       this._completed[peer.name] = Object.assign({}, peer)
     }
     delete this._state[peer.id]

--- a/sync.js
+++ b/sync.js
@@ -485,6 +485,7 @@ function WifiPeer (connection, info) {
   info.type = 'wifi'
   info.connection = connection
   info.swarmId = info.id // XXX: not used; for backwards compatibility
+  info.id = info.id.toString('hex')
   return info
 }
 

--- a/sync.js
+++ b/sync.js
@@ -250,7 +250,7 @@ class Sync extends events.EventEmitter {
       })
     }
 
-    if (this._destroyingSwarm) this.on('close', _listen)
+    if (this._destroyingSwarm) this.once('close', _listen)
     else _listen()
   }
 

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -29,7 +29,9 @@ function createApi (_, opts) {
     id: randombytes(8).toString('hex')
   }))
 
-  // TODO: expose a cleanup function
+  osm.close = function (cb) {
+    this.index.close(cb)
+  }
 
   mapeo._dir = dir
   return mapeo

--- a/test/lifecycle.js
+++ b/test/lifecycle.js
@@ -47,7 +47,6 @@ test('should properly open and close', function (t) {
 test('should properly close before reopening', function (t) {
   var mapeo = helpers.createApi()
   mapeo.sync.listen(function () {
-    mapeo.close()
     mapeo.close(function () {
       mapeo.sync.listen(function () {
         mapeo.close(() => {
@@ -80,7 +79,6 @@ test('should properly close during a sync', function (t) {
         var peers1 = api1.sync.peers()
         var peers2 = api2.sync.peers()
         if (peers1.length >= 1 && peers2.length >= 1) {
-          console.log('syncing')
           sync(peers1[0])
         }
       }
@@ -88,9 +86,7 @@ test('should properly close during a sync', function (t) {
 
     function onerror (err) {
       t.ok(err)
-      console.log('closing api1')
       api1.close(function () {
-        console.log('closed api1')
         t.end()
       })
     }
@@ -104,7 +100,6 @@ test('should properly close during a sync', function (t) {
       })
       syncer.once('progress', function (progress) {
         api2.close(() => {
-          console.log('closed api2')
         })
       })
     }

--- a/test/lifecycle.js
+++ b/test/lifecycle.js
@@ -1,0 +1,112 @@
+var helpers = require('./helpers')
+var test = require('tape')
+var rimraf = require('rimraf')
+
+function createApis (opts, cb) {
+  if (!cb && typeof opts === 'function') {
+    cb = opts
+    opts = undefined
+  }
+  opts = opts || {}
+  var api1 = helpers.createApi(null, opts.api1)
+  var api2 = helpers.createApi(null, opts.api2)
+  api1.on('error', console.error)
+  api2.on('error', console.error)
+  function close (cb) {
+    cb = cb || function () {}
+    var pending = 2
+    function done () {
+      if (!--pending) {
+        rimraf(api1._dir, function () {
+          rimraf(api2._dir, function () {
+            cb()
+          })
+        })
+      }
+    }
+
+    api1.close(done)
+    api2.close(done)
+  }
+  api1.osm.ready(function () {
+    api2.osm.ready(function () {
+      cb(api1, api2, close)
+    })
+  })
+}
+
+test('should properly open and close', function (t) {
+  var mapeo = helpers.createApi()
+  mapeo.sync.listen(function () {
+    mapeo.close(function () {
+      t.end()
+    })
+  })
+})
+
+test('should properly close before reopening', function (t) {
+  var mapeo = helpers.createApi()
+  mapeo.sync.listen(function () {
+    mapeo.close()
+    mapeo.close(function () {
+      mapeo.sync.listen(function () {
+        mapeo.close(() => {
+          t.end()
+        })
+      })
+    })
+  })
+})
+
+
+test('should properly close during a sync', function (t) {
+  var opts = {api1:{deviceType:'desktop'}, api2:{deviceType:'desktop'}}
+  createApis(opts, function (api1, api2, close) {
+    var total = 50
+    var pending = 3
+    api2.sync.setName('device_2')
+
+    api1.sync.listen()
+    api1.sync.join()
+    api1.sync.once('peer', written.bind(null, null))
+    api2.sync.listen()
+    api2.sync.join()
+    api2.sync.once('peer', written.bind(null, null))
+    helpers.writeBigData(api1, total, written)
+
+    function written (err) {
+      t.error(err)
+      if (--pending === 0) {
+        var peers1 = api1.sync.peers()
+        var peers2 = api2.sync.peers()
+        if (peers1.length >= 1 && peers2.length >= 1) {
+          console.log('syncing')
+          sync(peers1[0])
+        }
+      }
+    }
+
+    function onerror (err) {
+      t.ok(err)
+      console.log('closing api1')
+      api1.close(function () {
+        console.log('closed api1')
+        t.end()
+      })
+    }
+
+    function sync (peer) {
+      t.equals(peer.name, 'device_2')
+      var syncer = api1.sync.replicate(peer)
+      syncer.on('error', onerror)
+      syncer.on('end', () => {
+        t.ok(true, 'replication complete')
+      })
+      syncer.once('progress', function (progress) {
+        api2.close(() => {
+          console.log('closed api2')
+        })
+      })
+    }
+  })
+})

--- a/test/sync.js
+++ b/test/sync.js
@@ -530,7 +530,7 @@ tape('sync: desktop <-> desktop photos', function (t) {
 })
 
 tape('sync: deletes are not synced back', function (t) {
-  t.plan(19)
+  t.plan(18)
 
   var deleted
 

--- a/test/sync.js
+++ b/test/sync.js
@@ -76,8 +76,6 @@ tape('sync: two servers find each other with default sync key', function (t) {
 
     api1.sync.listen(function () {
       api2.sync.listen(function () {
-        api1.sync.join()
-        api2.sync.join()
         api1.sync.once('peer', function (peer) {
           var peerId = peer.id.toString('hex')
           t.same(peerId, api2.sync.swarm.id.toString('hex'), 'api2 id cmp')
@@ -88,6 +86,8 @@ tape('sync: two servers find each other with default sync key', function (t) {
           t.same(peerId, api1.sync.swarm.id.toString('hex'), 'api1 id cmp')
           done()
         })
+        api1.sync.join()
+        api2.sync.join()
       })
     })
   })
@@ -110,8 +110,6 @@ tape('sync: two servers find each other with same projectKey', function (t) {
 
     api1.sync.listen(function () {
       api2.sync.listen(function () {
-        api1.sync.join(projectKey)
-        api2.sync.join(projectKey)
         api1.sync.once('peer', function (peer) {
           var peerId = peer.id.toString('hex')
           t.same(peerId, api2.sync.swarm.id.toString('hex'), 'api2 id cmp')
@@ -122,6 +120,8 @@ tape('sync: two servers find each other with same projectKey', function (t) {
           t.same(peerId, api1.sync.swarm.id.toString('hex'), 'api1 id cmp')
           done()
         })
+        api1.sync.join(projectKey)
+        api2.sync.join(projectKey)
       })
     })
   })
@@ -141,8 +141,6 @@ tape('sync: two servers with different projectKey don\'t find each other', funct
 
     api1.sync.listen(function () {
       api2.sync.listen(function () {
-        api1.sync.join(crypto.randomBytes(32))
-        api2.sync.join(crypto.randomBytes(32))
         api1.sync.once('peer', function (peer) {
           t.fail('Should not find peer')
           console.log(loggablePeer(peer))
@@ -151,6 +149,8 @@ tape('sync: two servers with different projectKey don\'t find each other', funct
           t.fail('Should not find peer')
           console.log(loggablePeer(peer))
         })
+        api1.sync.join(crypto.randomBytes(32))
+        api2.sync.join(crypto.randomBytes(32))
       })
     })
   })

--- a/test/sync.js
+++ b/test/sync.js
@@ -195,8 +195,7 @@ tape('sync: remote peer error/destroyed is reflected in peer state', function (t
 })
 
 tape('sync: replication of a simple observation with media', function (t) {
-  t.plan(15)
-  var complete = false
+  t.plan(14)
 
   createApis(function (api1, api2, close) {
     var obs = {lat: 1, lon: 2, type: 'observation'}
@@ -240,7 +239,6 @@ tape('sync: replication of a simple observation with media', function (t) {
         t.fail()
       })
       syncer.on('end', function () {
-        complete = true
         t.ok(true, 'replication complete')
         api1.osm.get(id, function (err, node) {
           t.error(err)
@@ -251,12 +249,9 @@ tape('sync: replication of a simple observation with media', function (t) {
               t.error(err)
               t.ok(exists)
               close(function () {
-                t.ok(true)
-                if (complete) {
-                  t.same(peer.state.topic, 'replication-complete')
-                  var date = new Date(peer.state.message)
-                  t.ok(date.getTime() < new Date().getTime(), 'last completed date')
-                }
+                t.same(peer.state.topic, 'replication-complete')
+                const date = new Date(peer.state.message)
+                t.ok(date.getTime() < new Date().getTime(), 'last completed date')
               })
             })
           })
@@ -829,7 +824,8 @@ tape('sync: with two peers available, sync with one only triggers events for one
           setTimeout(function () {
             var peers = api1.sync.peers()
             peers.forEach((p) => {
-              t.same(p.state.topic, 'replication-wifi-ready')
+              if (p === peer) t.same(p.state.topic, 'replication-complete')
+              else t.same(p.state.topic, 'replication-wifi-ready')
             })
             close1()
             close2()

--- a/test/sync.js
+++ b/test/sync.js
@@ -184,7 +184,7 @@ tape('sync: remote peer error/destroyed is reflected in peer state', function (t
         api2.sync.on('peer', check(api1))
         api1.sync.on('down', function () {
           var peers = api1.sync.peers()
-          t.same(peers.length, 0)
+          t.same(peers.length, 1)
         })
         api1.sync.join()
         api2.sync.join()

--- a/test/sync.js
+++ b/test/sync.js
@@ -827,9 +827,10 @@ tape('sync: with two peers available, sync with one only triggers events for one
 
       function doListen (api, cb) {
         api.sync.listen(() => {
-          api.sync.join()
+          let pending = 3
           api.once('error', console.error)
-          api.sync.once('peer', cb.bind(null, null))
+          api.sync.on('peer', () => { if (!--pending) cb() })
+          api.sync.join()
         })
       }
 
@@ -846,14 +847,12 @@ tape('sync: with two peers available, sync with one only triggers events for one
       function written (err) {
         t.error(err)
         if (--pending === 0) {
-          t.ok(api1.sync.peers().length > 0, 'api 1 has peers')
-          t.ok(api2.sync.peers().length > 0, 'api 2 has peers')
-          t.ok(api3.sync.peers().length > 0, 'api 3 has peers')
-          t.ok(api4.sync.peers().length > 0, 'api 4 has peers')
-          if (api1.sync.peers().length >= 1) {
-            target = api1.sync.peers()[0]
-            sync(target)
-          }
+          t.same(api1.sync.peers().length, 3, 'api 1 has 3 peers')
+          t.same(api2.sync.peers().length, 3, 'api 2 has 3 peers')
+          t.same(api3.sync.peers().length, 3, 'api 3 has 3 peers')
+          t.same(api4.sync.peers().length, 3, 'api 4 has 3 peers')
+          target = api1.sync.peers()[0]
+          sync(target)
         }
       }
 

--- a/test/sync.js
+++ b/test/sync.js
@@ -204,13 +204,14 @@ tape('sync: replication of a simple observation with media', function (t) {
     ws.on('finish', written)
     ws.on('error', written)
     ws.end('bar')
+
+    api1.sync.once('peer', written.bind(null, null))
+    api2.sync.on('peer', written.bind(null, null))
     api1.sync.listen(() => {
       api1.sync.join()
-      api1.sync.once('peer', written.bind(null, null))
     })
     api2.sync.listen(() => {
       api2.sync.join()
-      api2.sync.on('peer', written.bind(null, null))
     })
 
     function written (err) {
@@ -458,13 +459,13 @@ tape('sync: desktop <-> desktop photos', function (t) {
 
     api2.sync.setName('device_2')
 
+    api1.sync.once('peer', written.bind(null, null))
+    api2.sync.on('peer', written.bind(null, null))
     api1.sync.listen(() => {
       api1.sync.join()
-      api1.sync.once('peer', written.bind(null, null))
     })
     api2.sync.listen(() => {
       api2.sync.join()
-      api2.sync.once('peer', written.bind(null, null))
     })
     helpers.writeBigData(api1, total, written)
     writeBlob(api2, 'goodbye_world.png', written)
@@ -541,13 +542,13 @@ tape('sync: deletes are not synced back', function (t) {
 
     api2.sync.setName('device_2')
 
+    api1.sync.once('peer', written.bind(null, null))
+    api2.sync.on('peer', written.bind(null, null))
     api1.sync.listen(() => {
       api1.sync.join()
-      api1.sync.once('peer', written.bind(null, null))
     })
     api2.sync.listen(() => {
       api2.sync.join()
-      api2.sync.on('peer', written.bind(null, null))
     })
     helpers.writeBigData(api1, total, written)
     writeBlob(api2, 'goodbye_world.png', written)
@@ -649,13 +650,13 @@ tape('sync: mobile <-> desktop photos', function (t) {
     var mobile = api1
     var desktop = api2
 
+    api1.sync.once('peer', written.bind(null, null))
+    api2.sync.on('peer', written.bind(null, null))
     api1.sync.listen(() => {
       api1.sync.join()
-      api1.sync.once('peer', written.bind(null, null))
     })
     api2.sync.listen(() => {
       api2.sync.join()
-      api2.sync.on('peer', written.bind(null, null))
     })
     helpers.writeBigData(mobile, total, written)
     writeBlob(desktop, 'goodbye_world.png', written)
@@ -718,13 +719,13 @@ tape('sync: mobile <-> mobile photos', function (t) {
 
     var clone = api2
 
+    api1.sync.once('peer', written.bind(null, null))
+    api2.sync.on('peer', written.bind(null, null))
     api1.sync.listen(() => {
       api1.sync.join()
-      api1.sync.once('peer', written.bind(null, null))
     })
     api2.sync.listen(() => {
       api2.sync.join()
-      api2.sync.on('peer', written.bind(null, null))
     })
     helpers.writeBigData(api1, total, written)
     writeBlob(clone, 'goodbye_world.png', written)
@@ -859,13 +860,13 @@ tape('sync: destroy during sync is reflected in peer state', function (t) {
     var pending = 4
     var total = 20
 
+    api1.sync.once('peer', written.bind(null, null))
+    api2.sync.on('peer', written.bind(null, null))
     api1.sync.listen(() => {
       api1.sync.join()
-      api1.sync.once('peer', written.bind(null, null))
     })
     api2.sync.listen(() => {
       api2.sync.join()
-      api2.sync.on('peer', written.bind(null, null))
     })
     helpers.writeBigData(api1, total, written)
     writeBlob(api2, 'goodbye_world.png', written)
@@ -913,13 +914,13 @@ tape('sync: 200 photos', function (t) {
     var pending = 4
     var total = 200
 
+    api1.sync.once('peer', written.bind(null, null))
+    api2.sync.on('peer', written.bind(null, null))
     api1.sync.listen(() => {
       api1.sync.join()
-      api1.sync.once('peer', written.bind(null, null))
     })
     api2.sync.listen(() => {
       api2.sync.join()
-      api2.sync.on('peer', written.bind(null, null))
     })
     helpers.writeBigData(api1, total, written)
     writeBlob(api2, 'goodbye_world.png', written)

--- a/test/sync.js
+++ b/test/sync.js
@@ -71,12 +71,12 @@ tape('sync: two servers find each other with default sync key', function (t) {
         api1.sync.join()
         api2.sync.join()
         api1.sync.on('peer', function (peer) {
-          var peerId = peer.swarmId.toString('hex')
+          var peerId = peer.id.toString('hex')
           t.same(peerId, api2.sync.swarm.id.toString('hex'), 'api2 id cmp')
           done()
         })
         api2.sync.on('peer', function (peer) {
-          var peerId = peer.swarmId.toString('hex')
+          var peerId = peer.id.toString('hex')
           t.same(peerId, api1.sync.swarm.id.toString('hex'), 'api1 id cmp')
           done()
         })
@@ -102,12 +102,12 @@ tape('sync: two servers find each other with same projectKey', function (t) {
         api1.sync.join(projectKey)
         api2.sync.join(projectKey)
         api1.sync.on('peer', function (peer) {
-          var peerId = peer.swarmId.toString('hex')
+          var peerId = peer.id.toString('hex')
           t.same(peerId, api2.sync.swarm.id.toString('hex'), 'api2 id cmp')
           done()
         })
         api2.sync.on('peer', function (peer) {
-          var peerId = peer.swarmId.toString('hex')
+          var peerId = peer.id.toString('hex')
           t.same(peerId, api1.sync.swarm.id.toString('hex'), 'api1 id cmp')
           done()
         })
@@ -179,7 +179,7 @@ tape('sync: remote peer error/destroyed is reflected in peer state', function (t
       api2.sync.listen(function () {
         function check (api) {
           return (peer) => {
-            var peerId = peer.swarmId.toString('hex')
+            var peerId = peer.id.toString('hex')
             t.same(peerId, api.sync.swarm.id.toString('hex'), 'api2 id cmp')
             done()
           }
@@ -999,6 +999,6 @@ function writeBlob (api, filename, cb) {
 function loggablePeer (peer) {
   const { connection, handshake, sync, ...loggablePeer } = peer
   loggablePeer.channel = loggablePeer.channel && loggablePeer.channel.toString('hex')
-  loggablePeer.swarmId = loggablePeer.swarmId.toString('hex')
+  loggablePeer.id = loggablePeer.id.toString('hex')
   return loggablePeer
 }

--- a/test/sync.js
+++ b/test/sync.js
@@ -269,7 +269,7 @@ tape('sync: replication of a simple observation with media', function (t) {
               t.ok(exists)
               t.same(peer.state.topic, 'replication-complete')
               const date = new Date(peer.state.message)
-              t.ok(date.getTime() < new Date().getTime(), 'last completed date')
+              t.ok(date.getTime() <= new Date().getTime(), 'last completed date')
               close(function () {
                 t.pass('close ok')
               })

--- a/test/sync.js
+++ b/test/sync.js
@@ -71,12 +71,12 @@ tape('sync: two servers find each other with default sync key', function (t) {
       api2.sync.listen(function () {
         api1.sync.join()
         api2.sync.join()
-        api1.sync.on('peer', function (peer) {
+        api1.sync.once('peer', function (peer) {
           var peerId = peer.id.toString('hex')
           t.same(peerId, api2.sync.swarm.id.toString('hex'), 'api2 id cmp')
           done()
         })
-        api2.sync.on('peer', function (peer) {
+        api2.sync.once('peer', function (peer) {
           var peerId = peer.id.toString('hex')
           t.same(peerId, api1.sync.swarm.id.toString('hex'), 'api1 id cmp')
           done()
@@ -102,12 +102,12 @@ tape('sync: two servers find each other with same projectKey', function (t) {
       api2.sync.listen(function () {
         api1.sync.join(projectKey)
         api2.sync.join(projectKey)
-        api1.sync.on('peer', function (peer) {
+        api1.sync.once('peer', function (peer) {
           var peerId = peer.id.toString('hex')
           t.same(peerId, api2.sync.swarm.id.toString('hex'), 'api2 id cmp')
           done()
         })
-        api2.sync.on('peer', function (peer) {
+        api2.sync.once('peer', function (peer) {
           var peerId = peer.id.toString('hex')
           t.same(peerId, api1.sync.swarm.id.toString('hex'), 'api1 id cmp')
           done()
@@ -131,11 +131,11 @@ tape('sync: two servers with different projectKey don\'t find each other', funct
       api2.sync.listen(function () {
         api1.sync.join(crypto.randomBytes(32))
         api2.sync.join(crypto.randomBytes(32))
-        api1.sync.on('peer', function (peer) {
+        api1.sync.once('peer', function (peer) {
           t.fail('Should not find peer')
           console.log(loggablePeer(peer))
         })
-        api2.sync.on('peer', function (peer) {
+        api2.sync.once('peer', function (peer) {
           t.fail('Should not find peer')
           console.log(loggablePeer(peer))
         })
@@ -206,7 +206,7 @@ tape('sync: replication of a simple observation with media', function (t) {
     ws.end('bar')
 
     api1.sync.once('peer', written.bind(null, null))
-    api2.sync.on('peer', written.bind(null, null))
+    api2.sync.once('peer', written.bind(null, null))
     api1.sync.listen(() => {
       api1.sync.join()
     })
@@ -460,7 +460,7 @@ tape('sync: desktop <-> desktop photos', function (t) {
     api2.sync.setName('device_2')
 
     api1.sync.once('peer', written.bind(null, null))
-    api2.sync.on('peer', written.bind(null, null))
+    api2.sync.once('peer', written.bind(null, null))
     api1.sync.listen(() => {
       api1.sync.join()
     })
@@ -543,7 +543,7 @@ tape('sync: deletes are not synced back', function (t) {
     api2.sync.setName('device_2')
 
     api1.sync.once('peer', written.bind(null, null))
-    api2.sync.on('peer', written.bind(null, null))
+    api2.sync.once('peer', written.bind(null, null))
     api1.sync.listen(() => {
       api1.sync.join()
     })
@@ -651,7 +651,7 @@ tape('sync: mobile <-> desktop photos', function (t) {
     var desktop = api2
 
     api1.sync.once('peer', written.bind(null, null))
-    api2.sync.on('peer', written.bind(null, null))
+    api2.sync.once('peer', written.bind(null, null))
     api1.sync.listen(() => {
       api1.sync.join()
     })
@@ -720,7 +720,7 @@ tape('sync: mobile <-> mobile photos', function (t) {
     var clone = api2
 
     api1.sync.once('peer', written.bind(null, null))
-    api2.sync.on('peer', written.bind(null, null))
+    api2.sync.once('peer', written.bind(null, null))
     api1.sync.listen(() => {
       api1.sync.join()
     })
@@ -861,7 +861,7 @@ tape('sync: destroy during sync is reflected in peer state', function (t) {
     var total = 20
 
     api1.sync.once('peer', written.bind(null, null))
-    api2.sync.on('peer', written.bind(null, null))
+    api2.sync.once('peer', written.bind(null, null))
     api1.sync.listen(() => {
       api1.sync.join()
     })
@@ -915,7 +915,7 @@ tape('sync: 200 photos', function (t) {
     var total = 200
 
     api1.sync.once('peer', written.bind(null, null))
-    api2.sync.on('peer', written.bind(null, null))
+    api2.sync.once('peer', written.bind(null, null))
     api1.sync.listen(() => {
       api1.sync.join()
     })


### PR DESCRIPTION
fixes #84, #83 

- peers are persisted across multiple connections
- peer instances are stable, so you can hold onto them across multiple syncs
- if a peer completes, then reconnects, it'll still be on the COMPLETE state
- if a peer errors, then reconnects, it'll still be on the ERROR state
- a variety of other bug fixes here and farther down the stack